### PR TITLE
Fix a performance problem in DIMEMessage._bytestream_to_pdv. 

### DIFF
--- a/pynetdicom3/dimse_messages.py
+++ b/pynetdicom3/dimse_messages.py
@@ -364,8 +364,6 @@ class DIMSEMessage(object):
             # Add the fragment to the output
             fragments.append(bytestream[start:start + length])
             start += length
-
-        assert bytestream == ''.join(fragments)
         return fragments
 
     def primitive_to_message(self, primitive):

--- a/pynetdicom3/dimse_messages.py
+++ b/pynetdicom3/dimse_messages.py
@@ -358,12 +358,14 @@ class DIMSEMessage(object):
         fragment_length -= 6
 
         fragments = []
-        while len(bytestream) > 0:
+        start = 0
+        while start < len(bytestream):
+            length = min(fragment_length, len(bytestream) - start)
             # Add the fragment to the output
-            fragments.append(bytestream[:fragment_length])
-            # Remove the added fragment from the bytestream
-            bytestream = bytestream[fragment_length:]
+            fragments.append(bytestream[start:start + length])
+            start += length
 
+        assert bytestream == ''.join(fragments)
         return fragments
 
     def primitive_to_message(self, primitive):


### PR DESCRIPTION
Its cost was quadratic to the length of the input. The new code has a linear cost.