### PR TITLE
Add parameter bind_addr to ApplicationEntity. 

### DIFF
--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -143,7 +143,8 @@ class ApplicationEntity(object):
     """
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     def __init__(self, ae_title='PYNETDICOM', port=0, scu_sop_class=None,
-                 scp_sop_class=None, transfer_syntax=None):
+                 scp_sop_class=None, transfer_syntax=None,
+                 bind_addr=''):
         """Create a new Application Entity.
 
         Parameters
@@ -153,6 +154,9 @@ class ApplicationEntity(object):
         port : int, optional
             The port number to listen for connections on when acting as an SCP
             (default: the first available port)
+        bind_addr : str, optional
+            The network interface to listen to.
+            (default: all availabel network interfaces on the machine)
         scu_sop_class : list of pydicom.uid.UID or list of str or list of
         pynetdicom3.sop_class.ServiceClass subclasses, optional
             List of the supported SOP Class UIDs when running as an SCU.
@@ -168,6 +172,7 @@ class ApplicationEntity(object):
         """
         self.address = platform.node()
         self.port = port
+        self.bind_addr = bind_addr
         self.ae_title = ae_title
 
         # Avoid dangerous default values
@@ -278,7 +283,7 @@ class ApplicationEntity(object):
         # The socket to listen for connections on, port is always specified
         self.local_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.local_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.local_socket.bind(('', self.port))
+        self.local_socket.bind((self.bind_addr, self.port))
         # Listen for connections made to the socket, the backlog argument
         #   specifies the maximum number of queued connections.
         self.local_socket.listen(1)

--- a/pynetdicom3/apps/storescp/storescp.py
+++ b/pynetdicom3/apps/storescp/storescp.py
@@ -48,6 +48,10 @@ def _setup_argparser():
     req_opts.add_argument("port",
                           help="TCP/IP port number to listen on",
                           type=int)
+    req_opts.add_argument("--bind_addr",
+                          help="The IP address of the network interface to "
+                          "listen on. If unset, listen on all interfaces.",
+                          default='')
 
     # General Options
     gen_opts = parser.add_argument_group('General Options')
@@ -281,6 +285,7 @@ scp_classes.append(VerificationSOPClass)
 # Create application entity
 ae = AE(ae_title=args.aetitle,
         port=args.port,
+        bind_addr=args.bind_addr,
         scu_sop_class=[],
         scp_sop_class=scp_classes,
         transfer_syntax=transfer_syntax)


### PR DESCRIPTION
It will restrict the network interface to listen on. This is useful when one wants a server to accept
connections only from a certain set of hosts (e.g., local processes)