### PR TITLE
Sets the Find SCP success response identifier to None

### DIFF
--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -565,6 +565,7 @@ class QueryRetrieveFindServiceClass(ServiceClass):
 
         # Send final success response
         rsp.Status = 0x0000
+        rsp.Identifier = None
         LOGGER.info('Find SCP Response: %s (Success)', ii + 2)
         self.DIMSE.send_msg(rsp, self.pcid)
 


### PR DESCRIPTION
Apologies if this is poorly explained as I'm not very familiar with the dicom standards, nor with pynetdicom3.

When using the dcmtk `findscu` utility to connect to a very simple pynetdicom3 SCU, I get the following warnings and error:
```sh
$ findscu -v -S -k QueryRetrieveLevel="STUDY" localhost 4006 2>&1 | grep -v I:
W: DIMSE Warning: (FINDSCU,ANY-SCP): findUser: Status Success, but DataSetType!=NULL
W: DIMSE Warning: (FINDSCU,ANY-SCP): Assuming no response identifiers are present
E: Association Release Failed: 0006:0316 DUL P-Data PDU arrived

$ findscu --version
$dcmtk: findscu v3.6.2 2017-07-14 $
```

I've traced this to the following section of the dcmtk where the final success response is expected to have a NULL identifier:
https://github.com/InsightSoftwareConsortium/DCMTK/blob/master/dcmnet/libsrc/dimfind.cc#L246-L256

This PR simply sets the success response identifier to None rather than leaving it as the last one sent as part of the find.