### PR TITLE
Fix empty find

### DIFF
--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -506,6 +506,7 @@ class QueryRetrieveFindServiceClass(ServiceClass):
             self.DIMSE.send_msg(rsp, self.pcid)
             return
 
+        ii = -1  # So if there are no results, log below doesn't break
         # Iterate through the results
         for ii, (rsp_status, rsp_identifier) in enumerate(result):
             # Validate rsp_status and set rsp.Status accordingly
@@ -535,7 +536,7 @@ class QueryRetrieveFindServiceClass(ServiceClass):
             elif status[0] == 'Success':
                 # User isn't supposed to send these, but handle anyway
                 # If success, then rsp_identifier is None
-                LOGGER.info('Find SCP Response: (Success)')
+                LOGGER.info('Find SCP Response: %s (Success)', ii + 1)
                 self.DIMSE.send_msg(rsp, self.pcid)
                 return
             elif status[0] == 'Pending':

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -1171,6 +1171,21 @@ class TestAssociationSendCFind(unittest.TestCase):
         assoc.release()
         scp.stop()
 
+    def test_rsp_empty(self):
+        """Test receiving a success response from the peer"""
+        scp = DummyFindSCP()
+        scp.statuses = []
+        scp.identifiers = []
+        scp.start()
+        ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelFind])
+        assoc = ae.associate('localhost', 11112)
+        self.assertTrue(assoc.is_established)
+        for (status, ds) in assoc.send_c_find(self.ds, query_model='P'):
+            self.assertEqual(status.Status, 0x0000)
+            self.assertEqual(ds, None)
+        assoc.release()
+        scp.stop()
+
     def test_rsp_cancel(self):
         """Test receiving a cancel response from the peer"""
         scp = DummyFindSCP()


### PR DESCRIPTION
When on_c_find is empty, which is should be in case there are no results (user is not supposed to return 0x0000 Success code), code breaks. Now fixed.