### PR TITLE
Make Presentation Contexts in ASSOC-AC conform to DICOM spec

### DIFF
--- a/pynetdicom3/acse.py
+++ b/pynetdicom3/acse.py
@@ -289,7 +289,8 @@ class ACSEServiceProvider(object):
         # Send response
         primitive.presentation_context_definition_list = []
         primitive.presentation_context_definition_results_list = \
-                                        self.accepted_contexts
+                                        self.accepted_contexts + \
+                                        self.rejected_contexts
         primitive.result = 0
 
         self.dul.send_pdu(primitive)

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -388,6 +388,7 @@ class Association(threading.Thread):
                                 self.ae.presentation_contexts_scp
 
         self.acse.accepted_contexts = self.acse.context_manager.accepted
+        self.acse.rejected_contexts = self.acse.context_manager.rejected
 
         # Set maximum PDU send length
         self.peer_max_pdu = assoc_rq.maximum_length_received # TODO: Remove?

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -478,22 +478,23 @@ class Association(threading.Thread):
                     pass
 
                 # Old method
-                matching_context = False
                 for context in self.acse.accepted_contexts:
                     if context.ID == msg_context_id:
                         sop_class.pcid = context.ID
                         sop_class.sopclass = context.AbstractSyntax
                         sop_class.transfersyntax = context.TransferSyntax[0]
-                        matching_context = True
-                if matching_context:
-                    # Most of these shouldn't be necessary
-                    sop_class.maxpdulength = self.peer_max_pdu
-                    sop_class.DIMSE = self.dimse
-                    sop_class.ACSE = self.acse
-                    sop_class.AE = self.ae
+                        sop_class.maxpdulength = self.peer_max_pdu
+                        sop_class.DIMSE = self.dimse
+                        sop_class.ACSE = self.acse
+                        sop_class.AE = self.ae
 
-                    # Run SOPClass in SCP mode
-                    sop_class.SCP(msg)
+                        # Run SOPClass in SCP mode
+                        sop_class.SCP(msg)
+                        break
+                else:
+                    LOGGER.info("Received message with invalid or rejected "
+                        "context ID %d", msg_context_id)
+                    LOGGER.debug("%s", msg)
 
             # Check for release request
             if self.acse.CheckRelease():

--- a/pynetdicom3/utils.py
+++ b/pynetdicom3/utils.py
@@ -527,7 +527,11 @@ class PresentationContextManager(object):
                 #   reject the current context (0x03 - abstract syntax not
                 #   supported)
                 if acc_context is None:
+                    # FIXME: make pdu not require this.
+                    result.TransferSyntax = [ii_req.TransferSyntax[0]]
                     result.Result = 0x03
+                    result = self.negotiate_scp_scu_role(ii_req, result)
+                    self.rejected.append(result)
 
                 # If there is a matching AbstractSyntax then check to see if the
                 #   Result attribute is None (indicates we are the Acceptor) or
@@ -542,19 +546,17 @@ class PresentationContextManager(object):
                         for transfer_syntax in acc_context.TransferSyntax:
                             # The local transfer syntax is used in order to
                             #   enforce preference based on position
-                            matching_ts = False
                             if transfer_syntax in ii_req.TransferSyntax:
                                 result.TransferSyntax = [transfer_syntax]
                                 result.Result = 0x00
                                 result = self.negotiate_scp_scu_role(ii_req,
                                                                      result)
                                 self.accepted.append(result)
-
-                                matching_ts = True
                                 break
 
                         # Refuse sop class because TS not supported
-                        if not matching_ts:
+                        else:
+                            # FIXME: make pdu not require this.
                             result.TransferSyntax = [transfer_syntax]
                             result.Result = 0x04
                             result = self.negotiate_scp_scu_role(ii_req, result)


### PR DESCRIPTION
By DICOM spec, all requested PCs from ASSOC-RQ should appear in
ASSOC-AC, either as accepted as rejected. Previously only the accepted
ones were present.