### PR TITLE
Fixed sending last find-result twice.

### DIFF
--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -511,9 +511,6 @@ class QueryRetrieveFindServiceClass(ServiceClass):
             # Validate rsp_status and set rsp.Status accordingly
             rsp = self.validate_status(rsp_status, rsp)
 
-            # Reset the response Identifier
-            rsp.Identifier = None
-
             if rsp.Status in self.statuses:
                 status = self.statuses[rsp.Status]
             else:
@@ -565,6 +562,9 @@ class QueryRetrieveFindServiceClass(ServiceClass):
                 LOGGER.debug('')
 
                 self.DIMSE.send_msg(rsp, self.pcid)
+
+            # Reset the response Identifier
+            rsp.Identifier = None
 
         # Send final success response
         rsp.Status = 0x0000


### PR DESCRIPTION
The last find-result that was sent, was sent a second time, along with the `Success` (0x0000) Status, which should not have any dataset with it.

It's difficult to write a test for it, because `on_c_find` doesn't attempt to parse the datasets of non `Pending` responses, so we need something lower-level to catch this.