### PR TITLE
Fix infinite loop

### DIFF
--- a/pynetdicom3/acse.py
+++ b/pynetdicom3/acse.py
@@ -162,11 +162,7 @@ class ACSEServiceProvider(object):
         #   This may be an A-ASSOCIATE confirmation primitive or an
         #   A-ABORT or A-P-ABORT request primitive
         #
-        if self.acse_timeout == 0:
-            # No timeout
-            assoc_rsp = self.dul.receive_pdu(True, None)
-        else:
-            assoc_rsp = self.dul.receive_pdu(True, self.acse_timeout)
+        assoc_rsp = self.dul.receive_pdu(wait=True, timeout=self.acse_timeout)
 
         # Association accepted or rejected
         if isinstance(assoc_rsp, A_ASSOCIATE):
@@ -317,7 +313,7 @@ class ACSEServiceProvider(object):
         primitive = A_RELEASE()
         self.dul.send_pdu(primitive)
 
-        return self.dul.receive_pdu(wait=True)
+        return self.dul.receive_pdu(wait=True, timeout=self.acse_timeout)
 
     def abort_assoc(self, source=0x02, reason=0x00):
         """Abort the Association with the peer Application Entity.

--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -377,7 +377,7 @@ class ApplicationEntity(object):
         self._quit = True
 
         for assoc in self.active_associations:
-            assoc.kill()
+            assoc.abort()
 
         if self.local_socket:
             self.local_socket.close()

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -450,7 +450,7 @@ class Association(threading.Thread):
 
             # Check with the DIMSE provider for incoming messages
             #   all messages should be a DIMSEMessage subclass
-            msg, msg_context_id = self.dimse.receive_msg(wait=True)
+            msg, msg_context_id = self.dimse.receive_msg(wait=False)
 
             # DIMSE message received
             if msg:
@@ -1119,7 +1119,9 @@ class Association(threading.Thread):
 
             # If no response received, start loop again
             if not rsp:
-                continue
+                LOGGER.error("Connection closed or timed-out")
+                self.abort()
+                return
             elif not rsp.is_valid_response:
                 LOGGER.error('Received an invalid C-FIND response from ' \
                              'the peer')
@@ -1343,7 +1345,9 @@ class Association(threading.Thread):
 
             # If nothing received from the peer, try again
             if not rsp:
-                continue
+                LOGGER.error("Connection closed or timed-out")
+                self.abort()
+                return
 
             # Received a C-MOVE response from the peer
             if rsp.__class__ == C_MOVE:
@@ -1607,7 +1611,9 @@ class Association(threading.Thread):
 
             # If nothing received from the peer, try again
             if not rsp:
-                continue
+                LOGGER.error("Connection closed or timed-out")
+                self.abort()
+                return
 
             # Received a C-GET response from the peer
             if rsp.__class__ == C_GET:

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -286,7 +286,7 @@ class Association(threading.Thread):
         time.sleep(0.1)
 
         # Got an A-ASSOCIATE request primitive from the DICOM UL
-        assoc_rq = self.dul.receive_pdu(wait=True)
+        assoc_rq = self.dul.receive_pdu(wait=True, timeout=self.acse.acse_timeout)
 
         if assoc_rq is None:
             self.kill()

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -515,7 +515,7 @@ class Association(threading.Thread):
 
             # Check if idle timer has expired
             if self.dul.idle_timer_expired():
-                self.kill()
+                self.abort()
 
     def _run_as_requestor(self):
         """Run as the Association Requestor."""

--- a/pynetdicom3/dimse.py
+++ b/pynetdicom3/dimse.py
@@ -295,7 +295,7 @@ class DIMSEServiceProvider(object):
                     continue
 
                 if nxt.__class__ is not P_DATA:
-                    return None, None
+                    continue
 
                 pdu = self.dul.receive_pdu(wait, self.dimse_timeout)
 
@@ -315,8 +315,6 @@ class DIMSEServiceProvider(object):
                     self.message = None
 
                     return primitive, context_id
-
-                return None, None
 
         else:
             cls = self.dul.peek_next_pdu().__class__

--- a/pynetdicom3/dul.py
+++ b/pynetdicom3/dul.py
@@ -229,9 +229,9 @@ class DULServiceProvider(Thread):
             be nice.
         """
         # Main DUL loop
+        if self._idle_timer is not None:
+            self._idle_timer.start()
         while True:
-            if self._idle_timer is not None:
-                self._idle_timer.start()
 
             # This effectively controls how often the DUL checks the network
             time.sleep(self._run_loop_delay)

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -362,19 +362,27 @@ class TestAEGoodAssociation(unittest.TestCase):
     def test_association_acse_timeout(self):
         """ Check that the Association timeouts are being set correctly """
         self.scp = DummyVerificationSCP()
-        self.scp.ae.acse_timeout = 0
-        self.scp.ae.dimse_timeout = 0
         self.scp.start()
 
         ae = AE(scu_sop_class=[VerificationSOPClass])
+
+        # self.scp.ae.acse_timeout = 0
+        # self.scp.ae.dimse_timeout = 0
+
+        # ae.acse_timeout = 30
+        # ae.dimse_timeout = 30
+        # assoc = ae.associate('localhost', 11112)
+        # time.sleep(1)
+        # self.assertTrue(len(self.scp.ae.active_associations) == 0)
+
+        self.scp.ae.acse_timeout = None
+        self.scp.ae.dimse_timeout = None
+
         ae.acse_timeout = 0
         ae.dimse_timeout = 0
         assoc = ae.associate('localhost', 11112)
-        self.assertTrue(self.scp.ae.active_associations[0].acse_timeout == 0)
-        self.assertTrue(self.scp.ae.active_associations[0].dimse_timeout == 0)
-        self.assertTrue(assoc.acse_timeout == 0)
-        self.assertTrue(assoc.dimse_timeout == 0)
-        assoc.release()
+        time.sleep(0.1)
+        self.assertTrue(len(self.scp.ae.active_associations) == 0)
 
         self.scp.ae.acse_timeout = 21
         self.scp.ae.dimse_timeout = 22

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -359,8 +359,9 @@ class TestAEGoodAssociation(unittest.TestCase):
 
         self.scp.stop()
 
-    def test_association_acse_timeout(self):
-        """ Check that the Association timeouts are being set correctly """
+    def test_association_timeouts(self):
+        """ Check that the Association timeouts are being set correctly and
+        work """
         self.scp = DummyVerificationSCP()
         self.scp.start()
 
@@ -373,17 +374,25 @@ class TestAEGoodAssociation(unittest.TestCase):
         ae.acse_timeout = 30
         ae.dimse_timeout = 30
         assoc = ae.associate('localhost', 11112)
-        time.sleep(0.5)
+        time.sleep(1)
         self.assertTrue(len(self.scp.ae.active_associations) == 0)
 
         self.scp.ae.acse_timeout = None
         self.scp.ae.dimse_timeout = None
         self.scp.ae.network_timeout = None
 
-        ae.acse_timeout = 0
+        ae.acse_timeout = 30
         ae.dimse_timeout = 0
+        self.scp.delay = 1
         assoc = ae.associate('localhost', 11112)
-        time.sleep(0.5)
+        assoc.send_c_echo()
+        time.sleep(2)
+        self.assertTrue(len(self.scp.ae.active_associations) == 0)
+
+        ae.acse_timeout = 0
+        ae.dimse_timeout = 30
+        assoc = ae.associate('localhost', 11112)
+        time.sleep(1)
         self.assertTrue(len(self.scp.ae.active_associations) == 0)
 
         self.scp.ae.acse_timeout = 21
@@ -392,7 +401,8 @@ class TestAEGoodAssociation(unittest.TestCase):
         ae.dimse_timeout = 32
 
         assoc = ae.associate('localhost', 11112)
-        time.sleep(0.5)
+        assoc.send_c_echo()
+        time.sleep(2)
         self.assertTrue(self.scp.ae.active_associations[0].acse_timeout == 21)
         self.assertTrue(self.scp.ae.active_associations[0].dimse_timeout == 22)
         self.assertTrue(assoc.acse_timeout == 31)

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -366,22 +366,24 @@ class TestAEGoodAssociation(unittest.TestCase):
 
         ae = AE(scu_sop_class=[VerificationSOPClass])
 
-        # self.scp.ae.acse_timeout = 0
-        # self.scp.ae.dimse_timeout = 0
+        self.scp.ae.acse_timeout = 0
+        self.scp.ae.dimse_timeout = 0
+        self.scp.ae.network_timeout = 0.2
 
-        # ae.acse_timeout = 30
-        # ae.dimse_timeout = 30
-        # assoc = ae.associate('localhost', 11112)
-        # time.sleep(1)
-        # self.assertTrue(len(self.scp.ae.active_associations) == 0)
+        ae.acse_timeout = 30
+        ae.dimse_timeout = 30
+        assoc = ae.associate('localhost', 11112)
+        time.sleep(0.5)
+        self.assertTrue(len(self.scp.ae.active_associations) == 0)
 
         self.scp.ae.acse_timeout = None
         self.scp.ae.dimse_timeout = None
+        self.scp.ae.network_timeout = None
 
         ae.acse_timeout = 0
         ae.dimse_timeout = 0
         assoc = ae.associate('localhost', 11112)
-        time.sleep(0.1)
+        time.sleep(0.5)
         self.assertTrue(len(self.scp.ae.active_associations) == 0)
 
         self.scp.ae.acse_timeout = 21
@@ -390,6 +392,7 @@ class TestAEGoodAssociation(unittest.TestCase):
         ae.dimse_timeout = 32
 
         assoc = ae.associate('localhost', 11112)
+        time.sleep(0.5)
         self.assertTrue(self.scp.ae.active_associations[0].acse_timeout == 21)
         self.assertTrue(self.scp.ae.active_associations[0].dimse_timeout == 22)
         self.assertTrue(assoc.acse_timeout == 31)


### PR DESCRIPTION
If associations were aborted while waiting for response, we got infinite loop. This is fixed.
Also, handling of timeouts is now better, with acse_ and dimse_ handled everywhere in SCUs, and acse_ and network_ handled in SCPs.