### PR TITLE
Add PresentationService, tests and benchmarks.

### DIFF
--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -454,21 +454,21 @@ class ApplicationEntity(object):
         str_out += "\n"
         str_out += "  Available Transfer Syntax(es):\n"
         for syntax in self.transfer_syntaxes:
-            str_out += "\t{0!s}\n".format(syntax)
+            str_out += "\t{0!s}\n".format(syntax.name)
 
         str_out += "\n"
         str_out += "  Supported SOP Classes (SCU):\n"
         if not self.scu_supported_sop:
             str_out += "\tNone\n"
         for sop_class in self.scu_supported_sop:
-            str_out += "\t{0!s}\n".format(sop_class)
+            str_out += "\t{0!s}\n".format(sop_class.name)
 
         str_out += "\n"
         str_out += "  Supported SOP Classes (SCP):\n"
         if not self.scp_supported_sop:
             str_out += "\tNone\n"
         for sop_class in self.scp_supported_sop:
-            str_out += "\t{0!s}\n".format(sop_class)
+            str_out += "\t{0!s}\n".format(sop_class.name)
 
         str_out += "\n"
         str_out += "  ACSE timeout: {0!s} s\n".format(self.acse_timeout)
@@ -803,7 +803,7 @@ class ApplicationEntity(object):
               * 1 or 2, then return b''.
               * 3 then return the Kerberos Server ticket.
               * 4 then return the SAML response.
-              
+
             If the identity check fails then return None
         """
         raise NotImplementedError
@@ -822,7 +822,7 @@ class ApplicationEntity(object):
         after receiving a C-ECHO request and prior to sending the response.
 
         **Supported Service Classes**
-       
+
         Verification Service Class
 
         **Status**
@@ -962,7 +962,7 @@ class ApplicationEntity(object):
         Query/Retrieve Service Class
 
         **Status**
-    
+
         Success
 
         - 0x0000 - Success

--- a/pynetdicom3/benchmarks/bench_presentation.py
+++ b/pynetdicom3/benchmarks/bench_presentation.py
@@ -1,0 +1,265 @@
+"""Performance tests for the pyndx.presentation module."""
+
+from pydicom._uid_dict import UID_dictionary
+from pydicom.uid import UID
+
+from pynetdicom3 import StorageSOPClassList
+from pynetdicom3.presentation import PresentationContext, PresentationService
+from pynetdicom3.utils import PresentationContextManager
+
+
+class TimePresentationContext:
+    def setup(self):
+        self.contexts = []
+        for x in range(500):
+            self.contexts.append(
+                PresentationContext(1,
+                                    '1.2.840.10008.5.1.4.1.1.2',
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+    def time_create_single_transfer_syntax(self):
+        """Time the creation of 100 presentation contexts with a single ts"""
+        for x in range(500):
+            PresentationContext(
+                1,
+                '1.2.840.10008.5.1.4.1.1.2',
+                ['1.2.840.10008.1.2']
+            )
+
+    def time_create_double_transfer_syntax(self):
+        for x in range(500):
+            PresentationContext(
+                1,
+                '1.2.840.10008.5.1.4.1.1.2',
+                ['1.2.840.10008.1.2', '1.2.840.10008.1.2.1']
+            )
+
+    def time_create_triple_transfer_syntax(self):
+        for x in range(500):
+            PresentationContext(
+                1,
+                '1.2.840.10008.5.1.4.1.1.2',
+                [
+                    '1.2.840.10008.1.2',
+                    '1.2.840.10008.1.2.1',
+                    '1.2.840.10008.1.2.2'
+                ]
+            )
+
+    def time_create_from_sop(self):
+        """Test the time taken to create a PresentationContext from every
+        available standard DICOM UID.
+        """
+        for uid in UID_dictionary:
+            PresentationContext(
+                1,
+                uid,
+                [
+                    '1.2.840.10008.1.2',
+                    '1.2.840.10008.1.2.1',
+                    '1.2.840.10008.1.2.2'
+                ]
+            )
+
+    def time_create_from_sop_list(self):
+        """Test the time taken to create Presentation Contexts using the
+        predefined SOP Classes from the pyndx.sop_class module.
+        """
+        for ii, sop_class in enumerate(StorageSOPClassList):
+            PresentationContext(
+                ii * 2 + 1,
+                sop_class.UID,
+                [
+                    '1.2.840.10008.1.2',
+                    '1.2.840.10008.1.2.1',
+                    '1.2.840.10008.1.2.2'
+                ]
+            )
+
+
+class TimePresentationAcceptorRoleNegotiation(object):
+    """Time presentation context negotiation as acceptor with SCP/SCU Role
+    Selection
+    """
+    def setup(self):
+        # Requestor presentation contexts - max 126
+        self.requestor_contexts = []
+        self.requestor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                            '1.2.840.10008.1.2.1',
+                                            '1.2.840.10008.1.2.2']
+        for ii, sop in enumerate(StorageSOPClassList):
+            context = PresentationContext(ii * 2 + 1,
+                                          sop.UID,
+                                          ['1.2.840.10008.1.2',
+                                           '1.2.840.10008.1.2.1',
+                                           '1.2.840.10008.1.2.2'])
+            context.SCP = True
+            context.SCU = True
+            self.requestor_contexts.append(context)
+
+        # Acceptor presentation contexts - no max
+        self.acceptor_contexts = []
+        self.acceptor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                           '1.2.840.10008.1.2.1',
+                                           '1.2.840.10008.1.2.2']
+        for uid in UID_dictionary:
+            context = PresentationContext(1,
+                                uid,
+                                ['1.2.840.10008.1.2',
+                                 '1.2.840.10008.1.2.1',
+                                 '1.2.840.10008.1.2.2'])
+            context.SCP = True
+            context.SCU = False
+            self.acceptor_contexts.append(context)
+
+    def time_ps_ac_role(self):
+        """Time a presentation service with SCP/SCU role negotiation."""
+        presentation = PresentationService()
+        presentation.negotiate_as_requestor(self.requestor_contexts,
+                                            self.acceptor_contexts)
+
+
+    def time_pcm_ac_role(self):
+        """Time PresentationContextManager with SCP/SCU role negotiation."""
+        pcm = PresentationContextManager()
+        pcm.requestor_contexts = self.requestor_contexts
+        pcm.acceptor_contexts = self.acceptor_contexts
+
+
+class TimePresentationRequestorRoleNegotiation(object):
+    """Time presentation context negotiation as requestor with SCP/SCU Role
+    Selection
+    """
+    def setup(self):
+        # Requestor presentation contexts - max 126
+        self.requestor_contexts = []
+        self.requestor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                            '1.2.840.10008.1.2.1',
+                                            '1.2.840.10008.1.2.2']
+        for ii, sop in enumerate(StorageSOPClassList):
+            context = PresentationContext(ii * 2 + 1,
+                                sop.UID,
+                                ['1.2.840.10008.1.2',
+                                 '1.2.840.10008.1.2.1',
+                                 '1.2.840.10008.1.2.2'])
+            context.SCP = True
+            context.SCU = True
+            self.requestor_contexts.append(context)
+
+        # Acceptor presentation contexts - no max
+        self.acceptor_contexts = []
+        self.acceptor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                           '1.2.840.10008.1.2.1',
+                                           '1.2.840.10008.1.2.2']
+        for uid in UID_dictionary:
+            context = PresentationContext(1,
+                                          uid,
+                                          ['1.2.840.10008.1.2'])
+            context.Result = 0x00
+            context.SCP = True
+            context.SCU = True
+            self.acceptor_contexts.append(context)
+
+    def time_ps_rq_role(self):
+        """Time a presentation service with SCP/SCU role negotiation."""
+        presentation = PresentationService()
+        presentation.negotiate_as_requestor(self.requestor_contexts,
+                                            self.acceptor_contexts)
+
+
+    def time_pcm_rq_role(self):
+        """Time PresentationContextManager with SCP/SCU role negotiation."""
+        pcm = PresentationContextManager()
+        pcm.requestor_contexts = self.requestor_contexts
+        pcm.acceptor_contexts = self.acceptor_contexts
+
+
+class TimePresentationAcceptor(object):
+    """Time presentation context negotiation as acceptor"""
+    def setup(self):
+        # Requestor presentation contexts - max 126
+        self.requestor_contexts = []
+        self.requestor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                            '1.2.840.10008.1.2.1',
+                                            '1.2.840.10008.1.2.2']
+        for ii, sop in enumerate(StorageSOPClassList):
+            self.requestor_contexts.append(
+                PresentationContext(ii * 2 + 1,
+                                    sop.UID,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+        # Acceptor presentation contexts - no max
+        self.acceptor_contexts = []
+        self.acceptor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                           '1.2.840.10008.1.2.1',
+                                           '1.2.840.10008.1.2.2']
+        for uid in UID_dictionary:
+            self.acceptor_contexts.append(
+                PresentationContext(1,
+                                    uid,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+    def time_ps_ac_basic(self):
+        """Time a basic presentation service negotiation"""
+        presentation = PresentationService()
+
+        presentation.negotiate_as_acceptor(self.requestor_contexts,
+                                           self.acceptor_contexts)
+
+    def time_pcm_basic(self):
+        """Time a basic PresentationContextManager negotiation"""
+        pcm = PresentationContextManager()
+        pcm.requestor_contexts = self.requestor_contexts
+        pcm.acceptor_contexts = self.acceptor_contexts
+        accepted = pcm.accepted
+
+
+class TimePresentationRequestor(object):
+    """Time presentation context negotiation as requestor"""
+    def setup(self):
+        # Requestor presentation contexts - max 126
+        self.requestor_contexts = []
+        self.requestor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                            '1.2.840.10008.1.2.1',
+                                            '1.2.840.10008.1.2.2']
+        for ii, sop in enumerate(StorageSOPClassList):
+            self.requestor_contexts.append(
+                PresentationContext(ii * 2 + 1,
+                                    sop.UID,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+        # Acceptor presentation contexts - no max
+        self.acceptor_contexts = []
+        self.acceptor_transfer_syntaxes = ['1.2.840.10008.1.2',
+                                           '1.2.840.10008.1.2.1',
+                                           '1.2.840.10008.1.2.2']
+        for uid in UID_dictionary:
+            context = PresentationContext(1,
+                                          uid,
+                                          ['1.2.840.10008.1.2'])
+            context.Result = 0x00
+            self.acceptor_contexts.append(context)
+
+    def time_ps_rq_basic(self):
+        """Time a basic presentation service negotiation."""
+        presentation = PresentationService()
+        presentation.negotiate_as_requestor(self.requestor_contexts,
+                                            self.acceptor_contexts)
+
+    def time_pcm_rq_basic(self):
+        """Time a basic PresentationContextManager negotiation"""
+        pcm = PresentationContextManager()
+        pcm.requestor_contexts = self.requestor_contexts
+        pcm.acceptor_contexts = self.acceptor_contexts

--- a/pynetdicom3/pdu.py
+++ b/pynetdicom3/pdu.py
@@ -2631,7 +2631,7 @@ class AbstractSyntaxSubItem(PDU):
         s = "Abstract Syntax Sub-item\n"
         s += "  Item type: 0x{0:02x}\n".format(self.item_type)
         s += "  Item length: {0:d} bytes\n".format(self.item_length)
-        s += '  Syntax name: ={0!s}\n'.format(self.abstract_syntax)
+        s += '  Syntax name: ={0!s}\n'.format(self.abstract_syntax.name)
 
         return s
 
@@ -2791,7 +2791,7 @@ class TransferSyntaxSubItem(PDU):
         s += "  Item type: 0x{0:02x}\n".format(self.item_type)
         s += "  Item length: {0:d} bytes\n".format(self.item_length)
         s += '  Transfer syntax name: ={0!s}\n'.format(
-            self.transfer_syntax_name)
+            self.transfer_syntax_name.name)
 
         return s
 
@@ -3806,7 +3806,7 @@ class SCP_SCU_RoleSelectionSubItem(PDU):
         s += "  Item type: 0x{0:02x}\n".format(self.item_type)
         s += "  Item length: {0:d} bytes\n".format(self.item_length)
         s += "  UID length: {0:d} bytes\n".format(self.uid_length)
-        s += "  SOP Class UID: {0!s}\n".format(self.UID)
+        s += "  SOP Class UID: {0!s}\n".format(self.UID.name)
         s += "  SCU Role: {0:d}\n".format(self.SCU)
         s += "  SCP Role: {0:d}\n".format(self.SCP)
 
@@ -4040,7 +4040,7 @@ class UserIdentitySubItemRQ(PDU):
     """
     Represents the User Identity RQ Sub Item used in A-ASSOCIATE-RQ PDUs.
 
-    The User Identity RQ Sub Item requires the following 
+    The User Identity RQ Sub Item requires the following
     parameters (see PS3.7 Annex D.3.3.7.1):
 
         * Item type (1, fixed, 0x58)
@@ -4159,7 +4159,7 @@ class UserIdentitySubItemRQ(PDU):
         Encode the Item's parameter values into a bytes string
 
         TODO:
-        
+
         * Add checking prior to encode to ensure all parameters are valid
           (should check all extended negotiation items as these are
           typically user defined when local is Requesting)
@@ -4555,7 +4555,7 @@ class SOPClassExtendedNegotiationSubItem(PDU):
         s += "  Item length: {0:d} bytes\n".format(self.item_length)
         s += "  SOP class UID length: {0:d} bytes\n".format(
             self.sop_class_uid_length)
-        s += "  SOP class: ={0!s}\n".format(self.sop_class_uid)
+        s += "  SOP class: ={0!s}\n".format(self.sop_class_uid.name)
 
         # Python 2 compatibility
         app_info = self.service_class_application_information
@@ -4794,16 +4794,16 @@ class SOPClassCommonExtendedNegotiationSubItem(PDU):
         s += "  Item length: {0:d} bytes\n".format(self.item_length)
         s += "  SOP class UID length: {0:d} bytes\n".format(
             self.sop_class_uid_length)
-        s += "  SOP class: ={0!s}\n".format(self.sop_class_uid)
+        s += "  SOP class: ={0!s}\n".format(self.sop_class_uid.name)
         s += "  Service class UID length: {0:d} bytes\n".format(
             self.service_class_uid_length)
-        s += "  Service class UID: ={0!s}\n".format(self.service_class_uid)
+        s += "  Service class UID: ={0!s}\n".format(self.service_class_uid.name)
         s += "  Related general SOP class ID length: {0:d} bytes\n".format(
             self.related_general_sop_class_identification_length)
         s += "  Related general SOP class ID(s):\n"
 
         for ii in self.related_general_sop_class_identification:
-            s += "    ={0!s} ({1!s})\n".format(ii, ii.title())
+            s += "    ={0!s} ({1!s})\n".format(ii.name, ii.title())
 
         return s
 

--- a/pynetdicom3/presentation.py
+++ b/pynetdicom3/presentation.py
@@ -1,0 +1,573 @@
+"""Implementation of the Presentation service."""
+import logging
+
+from pydicom.uid import UID
+
+LOGGER = logging.getLogger('pyndx.presentation')
+
+
+class PresentationContext(object):
+    """Representation of a single A-ASSOCIATE Presentation Context item.
+
+    PS3.8 7.1.1
+    An A-ASSOCIATE request primitive will contain a Presentation Context
+    Definition List, which consists or one or more presentation contexts. Each
+    item contains an ID, an Abstract Syntax and a list of one or more Transfer
+    Syntaxes.
+
+    An A-ASSOCIATE response primitive will contain a Presentation Context
+    Definition Result List, which takes the form of a list of result values,
+    with a one-to-one correspondence with the Presentation Context Definition
+    List.
+
+    A Presentation Context defines the presentation of the data on an
+    Association. It consists of three components, a Presentation Context ID,
+    an Abstract Syntax Name and a list or one or more Transfer Syntax Names.
+
+    Only one Abstract Syntax shall be offered per Presentation Context. While
+    multiple Transfer Syntaxes may be offered per Presentation Context only
+    one shall be accepted.
+
+    The same Abstract Syntax can be used in more than one Presentation Context.
+
+    Rules
+    -----
+    - Each Presentation Context (request) contains:
+      - One ID, an odd integer between 0 and 255
+      - One Abstract Syntax
+      - One or more Transfer Syntaxes
+    - Each Presentation Context (response) contains:
+      - One ID, corresponding to a Presentation Context received from the
+        Requestor
+      - A Result, one of 0x00, 0x01, 0x02, 0x03 or 0x04
+      - A Transfer Syntax
+    - If the Result is not 0x00 then the Transfer Syntax in the reply shall be
+      ignored
+    - The same Abstract Syntax can be present in more than one Presententation
+      Context
+    - Only one Transfer Syntax can be accepted per Presentation Context.
+    - The Presentation Contexts may be sent by the Requestor in any order.
+    - The Presentation Contexts may be sent by the Acceptor in any order.
+
+    Attributes
+    ----------
+    ID : int
+        The presentation context ID, must be an odd integer between 1 and 255,
+        inclusive.
+    AbstractSyntax : pydicom.uid.UID
+        The abstract syntax
+    TransferSyntax : list of pydicom.uid.UID
+        The transfer syntax(es)
+    SCU : bool or None
+        If an Association acceptor:
+        - True to accept a requestor SCP/SCU Role Selection proposal for the
+          requestor to support the SCU role.to acting as an SCU for the current context
+        - False to disallow the requestor acting as an SCU (the requestor and
+          acceptor then revert to their default roles)
+        - None to not perform SCP/SCU Role Negotation.
+        If an Association requestor then you should add one or more
+        SCP_SCU_RoleSelectionSubItem items to the User Information items. If
+        that is the case then the following values will be set:
+        - True if the requestor act as an SCU for the current context
+        - False if the requestor not act as an SCU for the current
+          context
+        - None if no SCP_SCU_RoleSelectionSubItem has been added for the
+          context's AbstractSyntax.
+    SCP : bool or None
+        If an Association acceptor:
+        - True to allow requestor to acting as an SCP for the current context
+        - False to disallow the requestor acting as an SCP (the requestor and
+          acceptor then revert to their default roles)
+        - None to not perform SCP/SCU Role Negotation.
+        If an Association requestor then you should add one or more
+        SCP_SCU_RoleSelectionSubItem items to the User Information items. If
+        that is the case then the following values will be set:
+        - True if the requestor act as an SCP for the current context
+        - False if the requestor not act as an SCP for the current
+          context
+        - None if no SCP_SCU_RoleSelectionSubItem has been added for the
+          context's AbstractSyntax.
+    Result : int or None
+        If part of the A-ASSOCIATE request then None.
+        If part of the A-ASSOCIATE resposne then one of:
+            0x00, 0x01, 0x02, 0x03, 0x04
+    status : str
+        The string representation of the Result:
+            0x00 : 'acceptance',
+            0x01 : 'user rejection',
+            0x02 : 'provider rejection'
+            0x03 : 'abstract syntax not supported'
+            0x04 : 'transfer syntaxes not supported'
+
+    References
+    ----------
+    DICOM Standard, Part 7, Annex D.3.2, D.3.3.4
+    """
+    def __init__(self, ID=None, abstract_syntax=None, transfer_syntaxes=None):
+        """Create a new PresentaionContext.
+
+        Parameters
+        ----------
+        ID : int
+            An odd integer between 1 and 255 inclusive
+        abstract_syntax : pydicom.uid.UID, optional
+            The context's abstract syntax
+        transfer_syntaxes : list of pydicom.uid.UID, optional
+            The context's transfer syntax(es)
+        """
+        self.ID = ID
+        self.AbstractSyntax = abstract_syntax
+        self.TransferSyntax = transfer_syntaxes or []
+        self.Result = None
+
+        # Refactor, these should be private and used in conjunction with the
+        # SOPClass.SCP and .SCU values
+        self.SCU = None
+        self.SCP = None
+
+    def add_transfer_syntax(self, transfer_syntax):
+        """Append a transfer syntax to the Presentation Context.
+
+        Parameters
+        ----------
+        transfer_syntax : pydicom.uid.UID, bytes or str
+            The transfer syntax to add to the Presentation Context. For
+            Presentation contexts that are rejected the `transfer_syntax` may
+            be an empty UID.
+        """
+        # UID is a subclass of str
+        if isinstance(transfer_syntax, str):
+            transfer_syntax = UID(transfer_syntax)
+        elif isinstance(transfer_syntax, bytes):
+            transfer_syntax = UID(transfer_syntax.decode('utf-8'))
+        else:
+            raise TypeError('transfer_syntax must be a pydicom.uid.UID,' \
+                             ' bytes or str')
+
+        if transfer_syntax not in self.TransferSyntax and \
+                                                    transfer_syntax != '':
+
+            if not transfer_syntax.is_valid:
+                raise ValueError('Presentation Context attempted to add a '
+                                 'invalid UID')
+            # Issue #62: private transfer syntaxes may be used
+            if not transfer_syntax.is_private and \
+                                not transfer_syntax.is_transfer_syntax:
+                raise ValueError('Presentation Context attempted to add a '
+                                 'non-transfer syntax UID')
+            self.TransferSyntax.append(transfer_syntax)
+
+    def __eq__(self, other):
+        """Return True if `self` is equal to `other`."""
+        if isinstance(other, self.__class__):
+            return self.__dict__ == other.__dict__
+
+        return NotImplemented
+
+    def __ne__(self, other):
+        """Return inequality"""
+        return not self == other
+
+    def __str__(self):
+        """String representation of the Presentation Context."""
+        s = 'ID: {0!s}\n'.format(self.ID)
+
+        if self.AbstractSyntax is not None:
+            s += 'Abstract Syntax: {0!s}\n'.format(self.AbstractSyntax)
+
+        s += 'Transfer Syntax(es):\n'
+        for syntax in self.TransferSyntax:
+            s += '\t={0!s}\n'.format(syntax)
+
+        if self.Result is not None:
+            s += 'Result: {0!s}\n'.format(self.status)
+
+        return s
+
+    @property
+    def ID(self):
+        """Return the Presentation Context's ID parameter."""
+        return self._id
+
+    @ID.setter
+    def ID(self, value):
+        """Set the Presentation Context's ID parameter.
+
+        FIXME: Add Parameters section
+        """
+        if value is not None:
+            # pylint: disable=attribute-defined-outside-init
+            if not 1 <= value <= 255:
+                raise ValueError("Presentation Context ID must be an odd "
+                                 "integer between 1 and 255 inclusive")
+            elif value % 2 == 0:
+                raise ValueError("Presentation Context ID must be an odd "
+                                 "integer between 1 and 255 inclusive")
+
+        self._id = value
+
+
+    @property
+    def AbstractSyntax(self):
+        """Return the Presentation Context's Abstract Syntax parameter."""
+        return self._abstract_syntax
+
+    @AbstractSyntax.setter
+    def AbstractSyntax(self, uid):
+        """Set the Presentation Context's Abstract Syntax parameter.
+
+        Parameters
+        ----------
+        uid : str or bytes or pydicom.uid.UID
+            The abstract syntax UIDs
+        """
+        # pylint: disable=attribute-defined-outside-init
+        if uid is None:
+            self._abstract_syntax = None
+            return
+
+        if isinstance(uid, bytes):
+            uid = UID(uid.decode('utf-8'))
+        elif isinstance(uid, UID):
+            pass
+        elif isinstance(uid, str):
+            uid = UID(uid)
+        else:
+            raise TypeError("Presentation Context invalid type for abstract "
+                            "syntax")
+
+        if not uid.is_valid:
+            LOGGER.info('Presentation Context attempted to set an invalid '
+                        'abstract syntax UID')
+        else:
+            self._abstract_syntax = uid
+
+    @property
+    def TransferSyntax(self):
+        """Return the Presentation Context's Transfer Syntax parameter."""
+        return self._transfer_syntax
+
+    @TransferSyntax.setter
+    def TransferSyntax(self, uid_list):
+        """Set the Presentation Context's Transfer Syntax parameter.
+
+        Parameters
+        ----------
+        uid_list : list of str or bytes or pydicom.uid.UID
+            The transfer syntax UIDs
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self._transfer_syntax = []
+        if not isinstance(uid_list, list):
+            raise TypeError("transfer_syntaxes must be a list.")
+
+        for uid in uid_list:
+            if isinstance(uid, bytes):
+                uid = UID(uid.decode('utf-8'))
+            elif isinstance(uid, UID):
+                pass
+            elif isinstance(uid, str):
+                uid = UID(uid)
+            else:
+                raise ValueError("PresentationContext(): Invalid transfer "
+                                 "syntax item")
+
+            if not uid.is_valid:
+                LOGGER.info('Presentation Context attempted to set an invalid '
+                            'transfer syntax UID')
+                continue
+
+            if uid.is_private:
+                self._transfer_syntax.append(uid)
+            elif uid.is_transfer_syntax:
+                self._transfer_syntax.append(uid)
+
+    @property
+    def status(self):
+        """Return the status of the Presentation Context"""
+        if self.Result is None:
+            status = 'Pending'
+        elif self.Result == 0x00:
+            status = 'Accepted'
+        elif self.Result == 0x01:
+            status = 'User Rejected'
+        elif self.Result == 0x02:
+            status = 'Provider Rejected'
+        elif self.Result == 0x03:
+            status = 'Abstract Syntax Not Supported'
+        elif self.Result == 0x04:
+            status = 'Transfer Syntax(es) Not Supported'
+        else:
+            status = 'Unknown'
+
+        return status
+
+
+class PresentationService(object):
+    """Provides Presentation related services to the AE.
+
+    For each SOP Class or Meta SOP Class, a Presentation Context must be
+    negotiated such that this Presentation Context supports the associated
+    Abstract Syntax and a suitable Transfer Syntax.
+
+    * The Association requestor may off multiple Presentation Contexts per
+    Association.
+    * Each Presentation Context supports one Abstract Syntax and one or more
+    Transfer Syntaxes.
+    * The Association acceptor may accept or reject each Presentation Context
+    individually.
+    * The Association acceptor selects a suitable Transfer Syntax for each
+    Presentation Context accepted.
+
+    SCP/SCU Role Selection Negotiation
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    The SCP/SCU role selection negotiation allows peer AEs to negotiate the
+    roles in which they will server for each SOP Class or Meta SOP Class
+    supported on the Association. This negotiation is optional.
+
+    The Association requestor, for each SOP Class UID or Meta SOP Class UID,
+    may use one SCP/SCU Role Selection item, with the SOP Class or Meta SOP
+    Class identified by its corresponding Abstract Syntax Name, followed by
+    one of the three role values:
+    * Association requestor is SCU only
+    * Association requestor is SCP only
+    * Association requestor is both SCU and SCP
+
+    If the SCP/SCU Role Selection item is absent then the Association requestor
+    shall be SCU and the Association acceptor shall be SCP.
+
+    References
+    ----------
+    DICOM Standard, Part 7, Annex D.3
+    """
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def negotiate(assoc):
+        """Process an Association's Presentation Contexts."""
+        if assoc._mode == 'acceptor':
+            self.negotiate_as_acceptor()
+        elif assoc._mode == 'requestor':
+            self.negotiate_as_requestor()
+
+    @staticmethod
+    def negotiate_as_acceptor(rq_contexts, ac_contexts):
+        """Process the Presentation Contexts as an Association acceptor.
+
+        Parameters
+        ----------
+        rq_contexts : list of PresentationContext
+            The Presentation Contexts proposed by the peer. Each item has
+            values for ID, AbstractSyntax and TransferSyntax. If the SCP/SCU
+            Role Selection Negotiation item was included in the A-ASSOCIATE
+            request then the PresentationContext.SCP and
+            PresentationContext.SCU values will be either True (supports the
+            role) or False (doesn't support the role).
+        ac_contexts : list of PresentationContext
+            The Presentation Contexts supported by the local AE when acting
+            as an Association acceptor. Each item has values for
+            AbstractSyntax and TransferSyntax. If Role Selection Negotiation
+            is supported then the SCU and SCP values will also both be
+            non-None.
+
+        Returns
+        -------
+        result_contexts : list of PresentationContext
+            The accepted presentation context items, each with a Result value
+            an ID, an AbstractSyntax, one TransferSyntax item and SCP and SCU
+            will also have values depending on the outcome of the SCP/SCU Role
+            Selection negotiation. Items are sorted in increasing ID value.
+        """
+        result_contexts = []
+
+        # No requestor presentation contexts
+        if not rq_contexts:
+            return result_contexts
+
+        # Acceptor doesn't support any presentation contexts
+        if not ac_contexts:
+            for rq_context in rq_contexts:
+                context = PresentationContext(rq_context.ID,
+                                              rq_context.AbstractSyntax,
+                                              [rq_context.TransferSyntax[0]])
+                context.Result = 0x03
+                result_contexts.append(context)
+            return result_contexts
+
+        # Optimisation notes (for iterating through contexts only, not
+        #   including actual context negotiation)
+        # - Create dict, use set intersection/difference of dict keys: ~600 us
+        # - Create dict, iterate over dict keys: ~400 us
+        # - Iterate over lists: ~52000 us
+
+        # Requestor may use the same Abstract Syntax in multiple Presentation
+        #   Contexts so we need a more specific key than UID
+        requestor_contexts = {
+            (cntx.ID, cntx.AbstractSyntax):cntx for cntx in rq_contexts
+        }
+        # Acceptor supported SOP Classes must be unique so we can use UID as
+        #   the key
+        acceptor_contexts = {cntx.AbstractSyntax:cntx for cntx in ac_contexts}
+
+        for (cntx_id, ab_syntax) in requestor_contexts:
+            # Convenience variable
+            rq_context = requestor_contexts[(cntx_id, ab_syntax)]
+
+            # Create a new PresentationContext item that will store the
+            #   results of the negotiation
+            context = PresentationContext(cntx_id, ab_syntax)
+
+            # Check if the acceptor supports the Abstract Syntax
+            if ab_syntax in acceptor_contexts:
+                # Convenience variable
+                ac_context = acceptor_contexts[ab_syntax]
+
+                # Abstract syntax supported so check Transfer Syntax
+                for tr_syntax in rq_context.TransferSyntax:
+
+                    # If transfer syntax supported
+                    if tr_syntax in ac_context.TransferSyntax:
+                        context.TransferSyntax = [tr_syntax]
+                        # Accept the presentation context
+                        context.Result = 0x00
+
+                        # SCP/SCU Role Selection needs to be reimplemented as it
+                        #   doesn't meet the DICOM Standard
+                        '''
+                        ## SCP/SCU Role Selection Negotiation
+                        # Only give an answer if the acceptor supports Role
+                        #   Selection Negotiation (i.e. `ac_context.SCU` and
+                        #   `ac_context.SCP` are not None)
+                        if None not in (ac_context.SCP, ac_context.SCU):
+                            # Requestor has proposed SCP role for context
+                            if rq_context.SCP:
+                                if ac_context.SCP:
+                                    context.SCP = True
+                                else:
+                                    context.SCP = False
+
+                            # Requestor has proposed SCU role for context
+                            if rq_context.SCU:
+                                if ac_context.SCU:
+                                    context.SCU = True
+                                else:
+                                    context.SCU = False
+                        '''
+
+                        result_contexts.append(context)
+                        break
+
+                # Need to check against None as 0x00 is a possible value
+                if context.Result is None:
+                    # Reject context - transfer syntax not supported
+                    context.Result = 0x04
+                    context.TransferSyntax = [rq_context.TransferSyntax[0]]
+                    result_contexts.append(context)
+            else:
+                # Reject context - abstract syntax not supported
+                context.Result = 0x03
+                context.TransferSyntax = [rq_context.TransferSyntax[0]]
+                result_contexts.append(context)
+
+        # Sort by presentation context ID and return
+        #   This isn't required by the DICOM Standard but its a nice thing to do
+        return sorted(result_contexts, key=lambda x: x.ID)
+
+    @staticmethod
+    def negotiate_as_requestor(rq_contexts, ac_contexts):
+        """Process the Presentation Contexts as an Association requestor.
+
+        The acceptor has processed the requestor's presentation context
+        definition list and returned the results. We want to do two things:
+        - Process the SCP/SCU Role Selection Negotiation (if any) (TO BE
+          IMPLEMENTED)
+        - Return a nice list of PresentationContexts with the Results and
+          original Abstract Syntax values to make things easier to use.
+
+        Presentation Context Item (RQ)
+        - Presentation context ID
+        - Abstract Syntax: one
+        - Transfer syntax: one or more
+
+        Presentation Context Item (AC)
+        - Presentation context ID
+        - Result: 0x00, 0x01, 0x02, 0x03, 0x04
+        - Transfer syntax: one, not to be tested if result is not 0x00
+
+        Parameters
+        ----------
+        rq_contexts : list of PresentationContext
+            The Presentation Contexts sent to the peer as the A-ASSOCIATE's
+            Presentation Context Definition List.
+        ac_contexts : list of PresentationContext
+            The Presentation Contexts return by the peer as the A-ASSOCIATE's
+            Presentation Context Definition Result List.
+
+        Returns
+        -------
+        list of PresentationContext
+            The contexts in the returned Presentation Context Definition Result
+            List, with added AbstractSyntax value and SCP/SCU Role Selection
+            values (if used). Items are sorted in increasing ID value.
+        """
+        if not rq_contexts:
+            raise ValueError('Requestor contexts are required')
+        output = []
+
+        # Create dicts, indexed by the presentation context ID
+        requestor_contexts = {context.ID:context for context in rq_contexts}
+        acceptor_contexts = {context.ID:context for context in ac_contexts}
+
+        for context_id in requestor_contexts:
+            # Convenience variable
+            rq_context = requestor_contexts[context_id]
+
+            context = PresentationContext(context_id,
+                                          rq_context.AbstractSyntax)
+
+            if context_id in acceptor_contexts:
+                # Convenience variable
+                ac_context = acceptor_contexts[context_id]
+
+                # Update with accepted values
+                context.TransferSyntax = [ac_context.TransferSyntax[0]]
+                context.Result = ac_context.Result
+
+                # SCP/SCU Role Selection needs to be reimplemented as it
+                #   doesn't meet the DICOM Standard
+                '''
+                ## SCP/SCU Role Selection Negotiation
+                # Skip if context rejected or acceptor ignored proposal
+                if (ac_context.Result == 0x00
+                            and None not in (ac_context.SCP, ac_context.SCU)):
+                    # Requestor has proposed SCP role for context:
+                    #   acceptor agrees: use agreed role
+                    #   acceptor disagrees: use default role
+                    if rq_context.SCP == ac_context.SCP:
+                        context.SCP = ac_context.SCP
+                    else:
+                        context.SCP = False
+
+                    # Requestor has proposed SCU role for context:
+                    #   acceptor agrees: use agreed role
+                    #   acceptor disagrees: use default role
+                    if rq_context.SCU == ac_context.SCU:
+                        context.SCU = ac_context.SCU
+                    else:
+                        context.SCU = False
+                else:
+                    # We are the association requestor, so SCU role only
+                    context.SCP = False
+                    context.SCU = True
+                '''
+
+            # Add any missing contexts as rejected
+            else:
+                context.TransferSyntax = [rq_context.TransferSyntax[0]]
+                context.Result = 0x02
+
+            output.append(context)
+
+        # Sort returned list by context ID
+        return sorted(output, key=lambda x: x.ID)

--- a/pynetdicom3/presentation.py
+++ b/pynetdicom3/presentation.py
@@ -173,11 +173,11 @@ class PresentationContext(object):
         s = 'ID: {0!s}\n'.format(self.ID)
 
         if self.AbstractSyntax is not None:
-            s += 'Abstract Syntax: {0!s}\n'.format(self.AbstractSyntax)
+            s += 'Abstract Syntax: {0!s}\n'.format(self.AbstractSyntax.name)
 
         s += 'Transfer Syntax(es):\n'
         for syntax in self.TransferSyntax:
-            s += '\t={0!s}\n'.format(syntax)
+            s += '\t={0!s}\n'.format(syntax.name)
 
         if self.Result is not None:
             s += 'Result: {0!s}\n'.format(self.status)

--- a/pynetdicom3/tests/test_presentation.py
+++ b/pynetdicom3/tests/test_presentation.py
@@ -1,0 +1,764 @@
+"""Tests for the pyndx.presentation module."""
+
+import pytest
+
+from pydicom._uid_dict import UID_dictionary
+from pydicom.uid import UID
+
+from pynetdicom3 import StorageSOPClassList
+from pynetdicom3.presentation import PresentationContext, PresentationService
+
+
+@pytest.fixture(params=[
+    (1, None, []),
+    (1, '1.1.1', ['1.2.840.10008.1.2']),
+    (1, '1.1.1', ['1.2.840.10008.1.2', '1.2.840.10008.1.2.1']),
+    (1, '1.1.1', ['1.2.840.10008.1.2', '1.2.840.10008.1.2.1', '1.2.3']),
+    (1, None, ['1.2.840.10008.1.2']),
+    (1, None, ['1.2.840.10008.1.2', '1.2.3']),
+    (1, '1.1.1', []),
+    (1, None, ['1.2.3']),
+    (1, None, ['1.2.3', '1.2.840.10008.1.2']),
+    (1, '1.2.840.10008.1.2.1.1.3', ['1.2.3']),
+    (1, '1.2.840.10008.1.2.1.1.3', ['1.2.3', '1.2.840.10008.1.2'])
+])
+def good_init(request):
+    """Good init values."""
+    return request.param
+
+@pytest.fixture(params=[
+    (1, None, [], []),
+    (1, '1.1.1', ['1.2.840.10008.1.1'], []),
+    (1, '1.1.1', ['1.2.840.10008.1.1'], ['1.2.840.10008.1.2.1']),
+    (1, '1.1.1', ['1.2.840.10008.1.1'], ['1.2.840.10008.1.2.1', '1.2.3']),
+    (1, None, ['1.2.840.10008.1.1'], []),
+    (1, None, ['1.2.840.10008.1.1'], ['1.2.3']),
+    (1, '1.2.840.10008.1.2.1.1.3', ['1.2.840.10008.1.1'], ['1.2.3'])
+])
+def mixed_init(request):
+    """Good init values with a mix of good and bad transfer syntaxes."""
+    return request.param
+
+
+class TestPresentationContext(object):
+    """Test the PresentationContext class"""
+    def test_good_init(self, good_init):
+        """Test the presentation context class init"""
+        (ID, abs_syn, tran_syn) = good_init
+        pc = PresentationContext(ID, abs_syn, tran_syn)
+        assert pc.ID == ID
+        assert pc.AbstractSyntax == abs_syn
+        assert pc.TransferSyntax == tran_syn
+        assert pc.SCU is None
+        assert pc.SCP is None
+        assert pc.Result is None
+
+    def test_mixed_init(self, mixed_init):
+        """Test the presentation context class init with some bad transfer"""
+        (ID, abs_syn, bad_tran, good_tran) = mixed_init
+        bad_tran.extend(good_tran)
+        pc = PresentationContext(ID, abs_syn, bad_tran)
+        assert pc.ID == ID
+        assert pc.AbstractSyntax == abs_syn
+        assert pc.TransferSyntax == good_tran
+        assert pc.SCU is None
+        assert pc.SCP is None
+        assert pc.Result is None
+
+    def test_bad_init(self):
+        """Test the presentation context class init"""
+        with pytest.raises(ValueError):
+            PresentationContext(0)
+        with pytest.raises(ValueError):
+            PresentationContext(256)
+        with pytest.raises(TypeError):
+            PresentationContext(1, transfer_syntaxes='1.1.1')
+        with pytest.raises(ValueError):
+            PresentationContext(1, transfer_syntaxes=[1234])
+        with pytest.raises(TypeError):
+            PresentationContext(1, abstract_syntax=['1.1.1.'])
+        with pytest.raises(TypeError):
+            PresentationContext(1, abstract_syntax=1234)
+
+    def test_add_transfer_syntax(self):
+        """Test adding transfer syntaxes"""
+        pc = PresentationContext(1)
+        pc.add_transfer_syntax('1.2.840.10008.1.2')
+        pc.add_transfer_syntax(b'1.2.840.10008.1.2.1')
+        pc.add_transfer_syntax(UID('1.2.840.10008.1.2.2'))
+        pc.add_transfer_syntax(UID(''))
+
+        with pytest.raises(TypeError):
+            pc.add_transfer_syntax([])
+
+        with pytest.raises(ValueError):
+            pc.add_transfer_syntax('1.2.3.')
+
+        with pytest.raises(ValueError):
+            pc.add_transfer_syntax('1.2.840.10008.1.1')
+
+    def test_add_private_transfer_syntax(self):
+        """Test adding private transfer syntaxes"""
+        pc = PresentationContext(1)
+        pc.add_transfer_syntax('2.16.840.1.113709.1.2.2')
+        assert '2.16.840.1.113709.1.2.2' in pc._transfer_syntax
+
+        pc.TransferSyntax = ['2.16.840.1.113709.1.2.1']
+        assert '2.16.840.1.113709.1.2.1' in pc._transfer_syntax
+
+    def test_equality(self):
+        """Test presentation context equality"""
+        pc_a = PresentationContext(1, '1.1.1', ['1.2.840.10008.1.2'])
+        pc_b = PresentationContext(1, '1.1.1', ['1.2.840.10008.1.2'])
+        assert pc_a == pc_a
+        assert pc_a == pc_b
+        assert not pc_a != pc_b
+        assert not pc_a != pc_a
+        pc_a.SCP = True
+        assert not pc_a == pc_b
+        pc_b.SCP = True
+        assert pc_a == pc_b
+        pc_a.SCU = True
+        assert not pc_a == pc_b
+        pc_b.SCU = True
+        assert pc_a == pc_b
+        assert not 'a' == pc_b
+
+    def test_string_output(self):
+        """Test string output"""
+        pc = PresentationContext(1, '1.1.1', ['1.2.840.10008.1.2'])
+        pc.SCP = True
+        pc.SCU = False
+        pc.Result = 0x0002
+        assert '1.1.1' in pc.__str__()
+        assert 'Implicit' in pc.__str__()
+        assert 'Provider Rejected' in pc.__str__()
+
+    def test_abstract_syntax(self):
+        """Test abstract syntax setter"""
+        pc = PresentationContext(1)
+        pc.AbstractSyntax = '1.1.1'
+        assert pc.AbstractSyntax == UID('1.1.1')
+        assert isinstance(pc.AbstractSyntax, UID)
+        pc.AbstractSyntax = b'1.2.1'
+        assert pc.AbstractSyntax == UID('1.2.1')
+        assert isinstance(pc.AbstractSyntax, UID)
+        pc.AbstractSyntax = UID('1.3.1')
+        assert pc.AbstractSyntax == UID('1.3.1')
+        assert isinstance(pc.AbstractSyntax, UID)
+
+        pc.AbstractSyntax = UID('1.4.1.')
+        assert pc.AbstractSyntax == UID('1.3.1')
+        assert isinstance(pc.AbstractSyntax, UID)
+
+    def test_transfer_syntax(self):
+        """Test transfer syntax setter"""
+        pc = PresentationContext(1)
+        pc.TransferSyntax = ['1.2.840.10008.1.2']
+
+        assert pc.TransferSyntax[0] == UID('1.2.840.10008.1.2')
+        assert isinstance(pc.TransferSyntax[0], UID)
+        pc.TransferSyntax = [b'1.2.840.10008.1.2.1']
+        assert pc.TransferSyntax[0] == UID('1.2.840.10008.1.2.1')
+        assert isinstance(pc.TransferSyntax[0], UID)
+        pc.TransferSyntax = [UID('1.2.840.10008.1.2.2')]
+        assert pc.TransferSyntax[0] == UID('1.2.840.10008.1.2.2')
+        assert isinstance(pc.TransferSyntax[0], UID)
+
+        with pytest.raises(TypeError):
+            pc.TransferSyntax = UID('1.4.1')
+
+        pc.TransferSyntax = ['1.4.1.', '1.2.840.10008.1.2']
+        assert pc.TransferSyntax[0] == UID('1.2.840.10008.1.2')
+
+    def test_status(self):
+        """Test presentation context status"""
+        pc = PresentationContext(1)
+        statuses = [None, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05]
+        results = ['Pending', 'Accepted', 'User Rejected', 'Provider Rejected',
+                   'Abstract Syntax Not Supported',
+                   'Transfer Syntax(es) Not Supported', 'Unknown']
+
+        for status, result in zip(statuses, results):
+            pc.Result = status
+            assert pc.status == result
+
+
+class TestPresentationServiceAcceptor(object):
+    """Tests for the PresentationService class when running as acceptor."""
+    def setup(self):
+        ps = PresentationService()
+        self.test_func = ps.negotiate_as_acceptor
+
+    def test_no_req_no_acc(self):
+        """Test negotiation with no contexts."""
+        result = self.test_func([], [])
+        assert result == []
+
+    def test_one_req_no_acc(self):
+        """Test negotiation with one requestor, no acceptor contexts."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        result = self.test_func([context], [])
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.TransferSyntax[0] == '1.2.840.10008.1.2'
+        assert len(context.TransferSyntax) == 1
+        assert context.Result == 0x03
+
+    def test_no_req_one_acc(self):
+        """Test negotiation with no requestor, one acceptor contexts."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        result = self.test_func([], [context])
+        assert result == []
+
+    def test_dupe_abs_req_no_acc(self):
+        """Test negotiation with duplicate requestor, no acceptor contexts."""
+        context_a = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        context_b = PresentationContext(3,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.1'])
+        context_c = PresentationContext(5,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.2'])
+        context_list = [context_a, context_b, context_c]
+        result = self.test_func(context_list, [])
+        assert len(result) == 3
+        for context in result:
+            assert context.ID in [1, 3, 5]
+            assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+            assert context.Result == 0x03
+
+    def test_dupe_abs_req(self):
+        """Test negotiation with duplicate requestor, no acceptor contexts."""
+        context_a = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        context_b = PresentationContext(3,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.1'])
+        context_c = PresentationContext(5,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.2'])
+        t_syntax = ['1.2.840.10008.1.2',
+                    '1.2.840.10008.1.2.1',
+                    '1.2.840.10008.1.2.2']
+        context_d = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        t_syntax)
+        context_list = [context_a, context_b, context_c]
+        result = self.test_func(context_list, [context_d])
+        assert len(result) == 3
+        for ii, context in enumerate(result):
+            assert context.ID in [1, 3, 5]
+            assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+            assert context.Result == 0x00
+            assert context.TransferSyntax == [t_syntax[ii]]
+
+    def test_one_req_one_acc_match(self):
+        """Test negotiation one req/acc, matching accepted."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        result = self.test_func([context], [context])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2']
+
+    def test_one_req_one_acc_accept_trans(self):
+        """Test negotiation one req/acc, matching accepted, multi trans."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2',
+                                       '1.2.840.10008.1.2.1',
+                                       '1.2.840.10008.1.2.2'])
+        result = self.test_func([context], [context])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2']
+
+    def test_one_req_one_acc_accept_trans_diff(self):
+        """Test negotiation one req/acc, matching accepted, multi trans."""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2',
+                                         '1.2.840.10008.1.2.1',
+                                         '1.2.840.10008.1.2.2'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2.2'])
+        result = self.test_func([context_a], [context_b])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2.2']
+
+    def test_one_req_one_acc_reject_trans(self):
+        """Test negotiation one req/acc, matching rejected trans"""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2',
+                                         '1.2.840.10008.1.2.1'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2.2'])
+        result = self.test_func([context_a], [context_b])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x04
+
+    def test_one_req_one_acc_mismatch(self):
+        """Test negotiation one req/acc, mismatched rejected"""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2',
+                                         '1.2.840.10008.1.2.1'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.4',
+                                        ['1.2.840.10008.1.2.1'])
+        result = self.test_func([context_a], [context_b])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x03
+
+    def test_private_transfer_syntax(self):
+        """Test negotiation with private transfer syntax"""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.3.4'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2.1',
+                                         '1.2.3.4'])
+        result = self.test_func([context_a], [context_b])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.3.4']
+
+    def test_private_abstract_syntax(self):
+        """Test negotiation with private abstract syntax"""
+        context_a = PresentationContext(1,
+                                        '1.2.3.4',
+                                        ['1.2.840.10008.1.2.1'])
+        context_b = PresentationContext(None,
+                                        '1.2.3.4',
+                                        ['1.2.840.10008.1.2.1'])
+        result = self.test_func([context_a], [context_b])
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.3.4'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2.1']
+
+    def test_typical(self):
+        """Test a typical set of presentation context negotiations."""
+        req_contexts = []
+        for ii, sop in enumerate(StorageSOPClassList):
+            req_contexts.append(
+                PresentationContext(ii * 2 + 1,
+                                    sop.UID,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+        acc_contexts = []
+        for uid in UID_dictionary:
+            acc_contexts.append(
+                PresentationContext(1,
+                                    uid,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+        results = self.test_func(req_contexts, acc_contexts)
+        assert len(results) == len(req_contexts)
+        for ii, context in enumerate(req_contexts):
+            assert results[ii].ID == context.ID
+            assert results[ii].AbstractSyntax == context.AbstractSyntax
+            if results[ii].AbstractSyntax == '1.2.840.10008.5.1.4.1.1.1.1.1.1':
+                assert results[ii].Result == 0x03
+            elif results[ii].AbstractSyntax == '1.2.840.10008.5.1.1.4.1.1.3.1':
+                assert results[ii].Result == 0x03
+            else:
+                assert results[ii].Result == 0x00
+                assert results[ii].TransferSyntax == ['1.2.840.10008.1.2']
+
+
+@pytest.mark.skip()
+class TestPresentationServiceAcceptorWithRoleSelection(object):
+    """Tests for the PresentationService as acceptor with role selection."""
+    @pytest.mark.parametrize("req, acc, out", [
+        ((None, None), (None, None), (False, True)),
+        ((None, None), (True, True), (False, True)),
+        ((None, None), (True, False), (False, True)),
+        ((None, None), (False, False), (False, True)),
+        ((None, None), (False, True), (False, True)),
+        ((True, True), (None, None), (False, True)),
+        ((True, True), (True, True), (True, True)),
+        ((True, True), (True, False), (True, True)),
+        ((True, True), (False, False), (False, True)),
+        ((True, True), (False, True), (False, True)),
+        ((False, True), (None, None), (False, True)),
+        ((False, True), (True, True), (False, True)),
+        ((False, True), (True, False), (False, True)),
+        ((False, True), (False, False), (False, True)),
+        ((False, True), (False, True), (False, True)),
+        ((False, False), (None, None), (False, True)),
+        ((False, False), (True, True), (False, True)),
+        ((False, False), (True, False), (False, False)),
+        ((False, False), (False, False), (False, False)),
+        ((False, False), (False, True), (False, True)),
+        ((True, False), (None, None), (False, True)),
+        ((True, False), (True, True), (True, True)),
+        ((True, False), (True, False), (True, False)),
+        ((True, False), (False, False), (False, False)),
+        ((True, False), (False, True), (False, True)),
+    ])
+    def test_scp_scu_role_negotiation(self, req, acc, out):
+        """Test presentation service negotiation with role selection."""
+        # Rules!
+        # - If the requestor doesn't ask, then there is no reply
+        # - If the requestor is False then the reply is False
+        # - If the requestor is True then the reply is either True or False
+        #   - If the acceptor is True then the reply is True
+        #   - If the acceptor is False then the reply is False
+        # Note: if the requestor and acceptor can't agree then the default
+        # roles should be used, which as we are acceptor is SCP True, SCU False
+        rq = PresentationContext(1,
+                                 '1.2.3.4',
+                                 ['1.2.840.10008.1.2'])
+        rq.SCP = req[0]
+        rq.SCU = req[1]
+
+        ac = PresentationContext(1,
+                                 '1.2.3.4',
+                                 ['1.2.840.10008.1.2'])
+        ac.SCP = acc[0]
+        ac.SCU = acc[0]
+        result = self.test_func([rq], [ac])
+
+        assert result[0].AbstractSyntax == '1.2.3.4'
+        assert result[0].TransferSyntax[0] == '1.2.840.10008.1.2'
+        assert result[0].SCP == out[0]
+        assert result[0].SCU == out[1]
+        assert result[0].Result == 0x00
+
+
+class TestPresentationServiceRequestor(object):
+    """Tests for the PresentationService class when running as requestor."""
+    def setup(self):
+        ps = PresentationService()
+        self.test_acc = ps.negotiate_as_acceptor
+        self.test_func = ps.negotiate_as_requestor
+
+    def test_no_req_no_acc_raise(self):
+        """Test negotiation with no contexts."""
+        with pytest.raises(ValueError):
+            result = self.test_func([], [])
+
+    def test_one_req_no_acc(self):
+        """Test negotiation with one requestor, no acceptor contexts."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        result = self.test_func([context], [])
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.TransferSyntax[0] == '1.2.840.10008.1.2'
+        assert len(context.TransferSyntax) == 1
+        assert context.Result == 0x02
+
+    def test_no_req_one_acc_raise(self):
+        """Test negotiation with no requestor, one acceptor contexts."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        with pytest.raises(ValueError):
+            result = self.test_func([], [context])
+
+    def test_dupe_abs_req_no_acc(self):
+        """Test negotiation with duplicate requestor, no acceptor contexts."""
+        context_a = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        context_b = PresentationContext(3,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.1'])
+        context_c = PresentationContext(5,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.2'])
+        rq_contexts = [context_a, context_b, context_c]
+        acc_contexts = self.test_acc(rq_contexts, [])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 3
+        for context in result:
+            assert context.ID in [1, 3, 5]
+            assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+            assert context.Result == 0x03
+
+    def test_dupe_abs_req(self):
+        """Test negotiation with duplicate requestor, no acceptor contexts."""
+        context_a = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        context_b = PresentationContext(3,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.1'])
+        context_c = PresentationContext(5,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2.2'])
+        t_syntax = ['1.2.840.10008.1.2',
+                    '1.2.840.10008.1.2.1',
+                    '1.2.840.10008.1.2.2']
+        context_d = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        t_syntax)
+
+        rq_contexts = [context_a, context_b, context_c]
+        acc_contexts = self.test_acc(rq_contexts, [context_d])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 3
+        for ii, context in enumerate(result):
+            assert context.ID in [1, 3, 5]
+            assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+            assert context.Result == 0x00
+            assert context.TransferSyntax == [t_syntax[ii]]
+
+    def test_one_req_one_acc_match(self):
+        """Test negotiation one req/acc, matching accepted."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2'])
+        rq_contexts = [context]
+        acc_contexts = self.test_acc([context], [context])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2']
+
+    def test_one_req_one_acc_accept_trans(self):
+        """Test negotiation one req/acc, matching accepted, multi trans."""
+        context = PresentationContext(1,
+                                      '1.2.840.10008.5.1.4.1.1.2',
+                                      ['1.2.840.10008.1.2',
+                                       '1.2.840.10008.1.2.1',
+                                       '1.2.840.10008.1.2.2'])
+        rq_contexts = [context]
+        acc_contexts = self.test_acc([context], [context])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2']
+
+    def test_one_req_one_acc_accept_trans_diff(self):
+        """Test negotiation one req/acc, matching accepted, multi trans."""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2',
+                                         '1.2.840.10008.1.2.1',
+                                         '1.2.840.10008.1.2.2'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2.2'])
+        rq_contexts = [context_a]
+        acc_contexts = self.test_acc(rq_contexts, [context_b])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2.2']
+
+    def test_one_req_one_acc_reject_trans(self):
+        """Test negotiation one req/acc, matching rejected trans"""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2',
+                                         '1.2.840.10008.1.2.1'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2.2'])
+        rq_contexts = [context_a]
+        acc_contexts = self.test_acc(rq_contexts, [context_b])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x04
+
+    def test_one_req_one_acc_mismatch(self):
+        """Test negotiation one req/acc, mismatched rejected"""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2',
+                                         '1.2.840.10008.1.2.1'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.4',
+                                        ['1.2.840.10008.1.2.1'])
+        rq_contexts = [context_a]
+        acc_contexts = self.test_acc(rq_contexts, [context_b])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x03
+
+    def test_private_transfer_syntax(self):
+        """Test negotiation with private transfer syntax"""
+        context_a = PresentationContext(1,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.3.4'])
+        context_b = PresentationContext(None,
+                                        '1.2.840.10008.5.1.4.1.1.2',
+                                        ['1.2.840.10008.1.2.1',
+                                         '1.2.3.4'])
+        rq_contexts = [context_a]
+        acc_contexts = self.test_acc(rq_contexts, [context_b])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.840.10008.5.1.4.1.1.2'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.3.4']
+
+    def test_private_abstract_syntax(self):
+        """Test negotiation with private abstract syntax"""
+        context_a = PresentationContext(1,
+                                        '1.2.3.4',
+                                        ['1.2.840.10008.1.2.1'])
+        context_b = PresentationContext(None,
+                                        '1.2.3.4',
+                                        ['1.2.840.10008.1.2.1'])
+        rq_contexts = [context_a]
+        acc_contexts = self.test_acc(rq_contexts, [context_b])
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        result = self.test_func(rq_contexts, acc_contexts)
+
+        assert len(result) == 1
+        context = result[0]
+        assert context.ID == 1
+        assert context.AbstractSyntax == '1.2.3.4'
+        assert context.Result == 0x00
+        assert context.TransferSyntax == ['1.2.840.10008.1.2.1']
+
+    def test_typical(self):
+        """Test a typical set of presentation context negotiations."""
+        req_contexts = []
+        for ii, sop in enumerate(StorageSOPClassList):
+            req_contexts.append(
+                PresentationContext(ii * 2 + 1,
+                                    sop.UID,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+        acc_contexts = []
+        for uid in UID_dictionary:
+            acc_contexts.append(
+                PresentationContext(1,
+                                    uid,
+                                    ['1.2.840.10008.1.2',
+                                     '1.2.840.10008.1.2.1',
+                                     '1.2.840.10008.1.2.2'])
+            )
+
+        acc_contexts = self.test_acc(req_contexts, acc_contexts)
+
+        for context in acc_contexts:
+            context.AbstractSyntax = None
+
+        results = self.test_func(req_contexts, acc_contexts)
+
+        assert len(results) == len(req_contexts)
+        for ii, context in enumerate(req_contexts):
+            assert results[ii].ID == context.ID
+            assert results[ii].AbstractSyntax == context.AbstractSyntax
+            if results[ii].AbstractSyntax == '1.2.840.10008.5.1.4.1.1.1.1.1.1':
+                assert results[ii].Result == 0x03
+            elif results[ii].AbstractSyntax == '1.2.840.10008.5.1.1.4.1.1.3.1':
+                assert results[ii].Result == 0x03
+            else:
+                assert results[ii].Result == 0x00
+                assert results[ii].TransferSyntax == ['1.2.840.10008.1.2']

--- a/pynetdicom3/utils.py
+++ b/pynetdicom3/utils.py
@@ -259,11 +259,11 @@ class PresentationContext(object):
         s = 'ID: {0!s}\n'.format(self.ID)
 
         if self.AbstractSyntax is not None:
-            s += 'Abstract Syntax: {0!s}\n'.format(self.AbstractSyntax)
+            s += 'Abstract Syntax: {0!s}\n'.format(self.AbstractSyntax.name)
 
         s += 'Transfer Syntax(es):\n'
         for syntax in self.TransferSyntax:
-            s += '\t={0!s}\n'.format(syntax)
+            s += '\t={0!s}\n'.format(syntax.name)
 
         if self.Result is not None:
             s += 'Result: {0!s}\n'.format(self.status)


### PR DESCRIPTION
Preparation for the refactor of Presentation related services.

#### Warnings
- SCP/SCU Role Selection negotiation not implemented in the new Presentation Service as the current pynetdicom3 implementtation is not actually conformant to the DICOM specification. It'll be added at a later point.
- The added PresentationService should be regarded as experimental and is part of ongoing work into the TransportService implementation/refactor and moving towards using gevent instead of Python threading.
