### PR TITLE
[MRG] Fixed handling of MAX_PDU=0

### DIFF
--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -421,8 +421,12 @@ class Association(threading.Thread):
         self.local_ae['port'] = local_info[1]
 
         # Set maximum PDU send length
-        self.peer_max_pdu = assoc_rq.maximum_length_received # TODO: Remove?
-        self.dimse.maximum_pdu_size = assoc_rq.maximum_length_received
+        if assoc_rq.maximum_length_received == 0:  # Unlimited PDU size - set to 64K as this is big enough to max out most protocols
+            self.peer_max_pdu = 0x10000
+            self.dimse.maximum_pdu_size = 0x10000
+        else:
+            self.peer_max_pdu = assoc_rq.maximum_length_received # TODO: Remove?
+            self.dimse.maximum_pdu_size = assoc_rq.maximum_length_received
 
         # Set Responding AE title
         assoc_rq.called_ae_title = self.ae.ae_title

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -454,10 +454,10 @@ class TestAEGoodAssociation(object):
         assert assoc.peer_max_pdu == 54321
         assoc.release()
 
-        # Check 0 max pdu value
+        # Check 0 max pdu value - max PDU value maps to 0x10000 internally
         assoc = ae.associate('localhost', 11112, max_pdu=0)
         assert assoc.local_max_pdu == 0
-        assert self.scp.ae.active_associations[0].peer_max_pdu == 0
+        assert self.scp.ae.active_associations[0].peer_max_pdu == 0x10000
         assoc.release()
 
         self.scp.stop()


### PR DESCRIPTION
MAX_PDU=0 should mean unlimited PDU but the code was subtracting 7 from this and
getting into trouble with a negative PDU size.  This change makes MAX_PDU=0 set
an internal PDU size of 64K.

#### Reference issue
#193 

#### Tasks
 - [X] Unit tests added that reproduce issue or prove feature is working
 - [X] Fix or feature added
 - [ ] Documentation updated (if relevant)
 - [X] Unit tests passing after adding fix/feature
 - [ ] Apps updated and tested (if relevant)
