### PR TITLE
[MPG] Fix sop_class errors.

### DIFF
--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -112,7 +112,7 @@ _VERIFICATION_CLASSES = {
 _STORAGE_CLASSES = {
     'ComputedRadiographyImageStorage' : '1.2.840.10008.5.1.4.1.1.1',  # A.2
     'DigitalXRayImagePresentationStorage' : '1.2.840.10008.5.1.4.1.1.1.1',  # A.26
-    'DigitalXRayImageProcessingStorage' : '1.2.840.10008.5.1.4.1.1.1.1.1.1',  # A.26
+    'DigitalXRayImageProcessingStorage' : '1.2.840.10008.5.1.4.1.1.1.1.1',  # A.26
     'DigitalMammographyXRayImagePresentationStorage' : '1.2.840.10008.5.1.4.1.1.1.2',  # A.27
     'DigitalMammographyXRayImageProcessingStorage' : '1.2.840.10008.5.1.4.1.1.1.2.1',  # A.27
     'DigitalIntraOralXRayImagePresentationStorage' : '1.2.840.10008.5.1.4.1.1.1.3',  # A.28


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
From [DICOM Storage Classes UID Reference](https://www.dicomlibrary.com/dicom/sop/), we learn that 
'DigitalXRayImageProcessingStorage' should be '1.2.840.10008.5.1.4.1.1.1.1.1' instead of '1.2.840.10008.5.1.4.1.1.1.1.1.1' . Due to mismatch, pynetdicom will produce 'not found error' for  'DigitalXRayImageProcessingStorage' class. 

#### Tasks
 - [ ] Unit tests added that reproduce issue or prove feature is working
 - [X] Fix or feature added
 - [ ] Documentation updated (if relevant)
 - [X] Unit tests passing after adding fix/feature
 - [X] Apps updated and tested (if relevant)
