### PR TITLE
[MRG] Fix sending datasets that don't match the presentation context

### DIFF
--- a/docs/examples/display.rst
+++ b/docs/examples/display.rst
@@ -32,7 +32,7 @@ Display System Management Service.
         #  response status a pydicom Dataset and the AttributeList dataset
         status, attr_list = assoc.send_n_get(
             [(0x0008,0x0070)],
-            DisplaySystemSOPClass.uid,
+            DisplaySystemSOPClass,
             '1.2.840.10008.5.1.1.40.1'
         )
 

--- a/docs/examples/qr_get.rst
+++ b/docs/examples/qr_get.rst
@@ -72,7 +72,7 @@ which requires adding the File Meta Information.
 
     # Add an SCP/SCU Role Selection Negotiation item for CT Image Storage
     role = SCP_SCU_RoleSelectionNegotiation()
-    role.sop_class_uid = CTImageStorage.uid
+    role.sop_class_uid = CTImageStorage
     # We will be acting as an SCP for CT Image Storage
     role.scp_role = True
 

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -799,33 +799,6 @@ class ApplicationEntity(object):
         """Stop the SCP."""
         self.stop()
 
-    def register(self, event, callback):
-        """Register `callback` with an `event`
-
-        Parameters
-        ----------
-        event : str
-            The event that will trigger `callback`. Possible events are:
-
-            * 'user-identity' : event occurs when an association acceptor
-              receives a User Identity Negotiation request as part of an
-              association request.
-            * 'sop-class-common' : event occurs when an association acceptor
-              receives one or more SOP Class Common Negotiation request as
-              part of an association request.
-            * 'sop-class-common-extended' : event occurs when an association
-              acceptor receives one or more SOP Class Common Extended
-              Negotiation items as part of an association request.
-            * 'asynchronous-operations' : event occurs when an association
-              acceptor receives an Asynchronous Operations Window Neogotiation
-              item as part of an association request.
-        callback : callable
-            The callback that will be called when `event` occurs. The arguments
-            and keyword arguments available to `callback` are dependent on
-            the `event`.
-        """
-        pass
-
     def remove_requested_context(self, abstract_syntax, transfer_syntax=None):
         """Remove a requested Presentation Context.
 
@@ -1384,16 +1357,6 @@ class ApplicationEntity(object):
 
             self.add_supported_context(item.abstract_syntax,
                                        item.transfer_syntax)
-
-    def unregister(self, event, callback):
-        """Unregister a `callback`.
-
-        Parameters
-        ----------
-        event : str
-        callback : callable
-        """
-        pass
 
     @staticmethod
     def _validate_requested_contexts(contexts):

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -799,6 +799,33 @@ class ApplicationEntity(object):
         """Stop the SCP."""
         self.stop()
 
+    def register(self, event, callback):
+        """Register `callback` with an `event`
+
+        Parameters
+        ----------
+        event : str
+            The event that will trigger `callback`. Possible events are:
+
+            * 'user-identity' : event occurs when an association acceptor
+              receives a User Identity Negotiation request as part of an
+              association request.
+            * 'sop-class-common' : event occurs when an association acceptor
+              receives one or more SOP Class Common Negotiation request as
+              part of an association request.
+            * 'sop-class-common-extended' : event occurs when an association
+              acceptor receives one or more SOP Class Common Extended
+              Negotiation items as part of an association request.
+            * 'asynchronous-operations' : event occurs when an association
+              acceptor receives an Asynchronous Operations Window Neogotiation
+              item as part of an association request.
+        callback : callable
+            The callback that will be called when `event` occurs. The arguments
+            and keyword arguments available to `callback` are dependent on
+            the `event`.
+        """
+        pass
+
     def remove_requested_context(self, abstract_syntax, transfer_syntax=None):
         """Remove a requested Presentation Context.
 
@@ -1358,6 +1385,16 @@ class ApplicationEntity(object):
             self.add_supported_context(item.abstract_syntax,
                                        item.transfer_syntax)
 
+    def unregister(self, event, callback):
+        """Unregister a `callback`.
+
+        Parameters
+        ----------
+        event : str
+        callback : callable
+        """
+        pass
+
     @staticmethod
     def _validate_requested_contexts(contexts):
         """Validate the supplied `contexts`.
@@ -1378,6 +1415,7 @@ class ApplicationEntity(object):
                 raise ValueError(
                     "'contexts' must be a list of PresentationContext items"
                 )
+
 
     # Association negotiation callbacks
     def on_user_identity_negotiation(self, user_id_type, primary_field,

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -340,10 +340,7 @@ class ApplicationEntity(object):
                 "are already the maximum allowed number of requested contexts"
             )
 
-        if hasattr(abstract_syntax, 'uid'):
-            abstract_syntax = UID(abstract_syntax.uid)
-        else:
-            abstract_syntax = UID(abstract_syntax)
+        abstract_syntax = UID(abstract_syntax)
 
         # Allow single transfer syntax values for convenience
         if isinstance(transfer_syntax, str):
@@ -467,10 +464,7 @@ class ApplicationEntity(object):
         ...     CTImageStorage, scu_role=True, scp_role=True
         ... )
         """
-        if hasattr(abstract_syntax, 'uid'):
-            abstract_syntax = UID(abstract_syntax.uid)
-        else:
-            abstract_syntax = UID(abstract_syntax)
+        abstract_syntax = UID(abstract_syntax)
 
         if not isinstance(scu_role, (type(None), bool)):
             raise TypeError("`scu_role` must be None or bool")
@@ -895,10 +889,7 @@ class ApplicationEntity(object):
         Transfer Syntax(es):
 	        =Explicit VR Big Endian
         """
-        if hasattr(abstract_syntax, 'uid'):
-            abstract_syntax = UID(abstract_syntax.uid)
-        else:
-            abstract_syntax = UID(abstract_syntax)
+        abstract_syntax = UID(abstract_syntax)
 
         # Get all the current requested contexts with the same abstract syntax
         matching_contexts = [
@@ -1018,10 +1009,7 @@ class ApplicationEntity(object):
         Transfer Syntax(es):
 	        =Explicit VR Big Endian
         """
-        if hasattr(abstract_syntax, 'uid'):
-            abstract_syntax = UID(abstract_syntax.uid)
-        else:
-            abstract_syntax = UID(abstract_syntax)
+        abstract_syntax = UID(abstract_syntax)
 
         if isinstance(transfer_syntax, str):
             transfer_syntax = [transfer_syntax]

--- a/pynetdicom3/apps/findscu/findscu.py
+++ b/pynetdicom3/apps/findscu/findscu.py
@@ -183,8 +183,8 @@ if assoc.is_established:
     response = assoc.send_c_find(identifier, query_model=query_model)
 
     for status, identifier in response:
-        #pass
         if status.Status in (0xFF00, 0xFF01):
-            print(identifier)
+            #print(identifier)
+            pass
 
     assoc.release()

--- a/pynetdicom3/apps/getscu/getscu.py
+++ b/pynetdicom3/apps/getscu/getscu.py
@@ -139,7 +139,7 @@ ae = AE(ae_title=args.calling_aet, port=0)
 
 for context in QueryRetrievePresentationContexts:
     ae.add_requested_context(context.abstract_syntax)
-for context in StoragePresentationContexts:
+for context in StoragePresentationContexts[:115]:
     ae.add_requested_context(context.abstract_syntax)
 
 # Add SCP/SCU Role Selection Negotiation to the extended negotiation

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -326,12 +326,6 @@ class Association(threading.Thread):
             if cx.abstract_syntax != ab_syntax:
                 continue
 
-            # Allow us to skip the transfer syntax check
-            if tr_syntax and cx.transfer_syntax[0] != tr_syntax:
-                # Compressed transfer syntaxes are not convertable
-                if tr_syntax.is_compressed or cx.transfer_syntax[0].is_compressed:
-                    continue
-
             # Cover both False and None
             if role == 'scu' and cx.as_scu is not True:
                 continue
@@ -339,13 +333,20 @@ class Association(threading.Thread):
             if role == 'scp' and cx.as_scp is not True:
                 continue
 
+            # Allow us to skip the transfer syntax check
+            if tr_syntax and tr_syntax != cx.transfer_syntax[0]:
+                # Compressed transfer syntaxes are not convertable
+                if (tr_syntax.is_compressed
+                        or cx.transfer_syntax[0].is_compressed):
+                    continue
+
             # Only a valid presentation context can reach this point
             return cx
 
         msg = (
-            "No presentation context for the {} role has been accepted by "
-            "the peer for the SOP Class '{}'"
-            .format(role.upper(), ab_syntax.name, tr_syntax.name)
+            "No suitable presentation context for the {} role has been "
+            "accepted by the peer for the SOP Class '{}'"
+            .format(role.upper(), ab_syntax.name)
         )
         if tr_syntax:
             msg += " with a transfer syntax of '{}'".format(tr_syntax.name)

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -1669,6 +1669,7 @@ class Association(threading.Thread):
                         LOGGER.error("Failed to decode the received Identifier "
                                      "dataset")
                         LOGGER.exception(ex)
+                        identifier = None
 
                 yield status, identifier
                 break
@@ -1972,6 +1973,7 @@ class Association(threading.Thread):
                         LOGGER.error("Failed to decode the received Identifier "
                                      "dataset")
                         LOGGER.exception(ex)
+                        identifier = None
 
                 yield status, identifier
                 break

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -1360,7 +1360,7 @@ class Association(threading.Thread):
         LOGGER.info('')
 
         # Send C-FIND request to the peer via DIMSE
-        self.dimse.send_msg(req, context_id)
+        self.dimse.send_msg(req, context.context_id)
 
         # Get the responses from the peer
         ii = 1
@@ -1624,7 +1624,7 @@ class Association(threading.Thread):
         LOGGER.info('')
 
         # Send C-MOVE request to the peer via DIMSE and wait for the response
-        self.dimse.send_msg(req, context_id)
+        self.dimse.send_msg(req, context.context_id)
 
         # Get the responses from peer
         operation_no = 1
@@ -1932,7 +1932,7 @@ class Association(threading.Thread):
         LOGGER.info('')
 
         # Send C-GET request to the peer via DIMSE
-        self.dimse.send_msg(req, context_id)
+        self.dimse.send_msg(req, context.context_id)
 
         # Get the responses from the peer
         operation_no = 1

--- a/pynetdicom3/dimse_messages.py
+++ b/pynetdicom3/dimse_messages.py
@@ -519,6 +519,9 @@ class DIMSEMessage(object):
         except KeyError:
             pass
 
+        # Set the presentation context ID the message was set under
+        primitive._context_id = self.ID
+
         return primitive
 
     def primitive_to_message(self, primitive):

--- a/pynetdicom3/dimse_primitives.py
+++ b/pynetdicom3/dimse_primitives.py
@@ -132,6 +132,8 @@ class C_STORE(object):
     * DICOM Standard, Part 4, Annex B
     * DICOM Standard, Part 7, 9.1.1
     """
+    STATUS_OPTIONAL_KEYWORDS = ('OffendingElement', 'ErrorComment', )
+
     def __init__(self):
         # Variable names need to match the corresponding DICOM Element keywords
         #   in order for the DIMSE Message classes to be built correctly.
@@ -484,6 +486,8 @@ class C_FIND(object):
         An optional status related field containing a text
         description of the error detected. 64 characters maximum.
     """
+    STATUS_OPTIONAL_KEYWORDS = ('OffendingElement', 'ErrorComment', )
+
     def __init__(self):
         # Variable names need to match the corresponding DICOM Element keywords
         #   in order for the DIMSE Message classes to be built correctly.
@@ -771,6 +775,12 @@ class C_GET(object):
     * DICOM Standard, Part 4, Annex C.4.3
     * DICOM Standard, Part 7, Section 9.1.3
     """
+    STATUS_OPTIONAL_KEYWORDS = (
+        'ErrorComment', 'OffendingElement', 'NumberOfRemainingSuboperations',
+        'NumberOfCompletedSuboperations', 'NumberOfFailedSuboperations',
+        'NumberOfWarningSuboperations'
+    )
+
     def __init__(self):
         # Variable names need to match the corresponding DICOM Element keywords
         #   in order for the DIMSE Message classes to be built correctly.
@@ -1146,6 +1156,12 @@ class C_MOVE(object):
     * DICOM Standard, Part 4, Annex C.4.2
     * DICOM Standard, Part 7, Section 9.1.4
     """
+    STATUS_OPTIONAL_KEYWORDS = (
+        'ErrorComment', 'OffendingElement', 'NumberOfRemainingSuboperations',
+        'NumberOfCompletedSuboperations', 'NumberOfFailedSuboperations',
+        'NumberOfWarningSuboperations'
+    )
+
     def __init__(self):
         # Variable names need to match the corresponding DICOM Element keywords
         #   in order for the DIMSE Message classes to be built correctly.
@@ -1453,6 +1469,8 @@ class C_ECHO(object):
 
     * DICOM Standard, Part 7, Section 9.1.5
     """
+    STATUS_OPTIONAL_KEYWORDS = ('ErrorComment', )
+
     def __init__(self):
         # Variable names need to match the corresponding DICOM Element keywords
         #   in order for the DIMSE Message classes to be built correctly.
@@ -1955,6 +1973,8 @@ class N_GET(object):
 
     DICOM Standard, Part 7, Section 10.1.2
     """
+    STATUS_OPTIONAL_KEYWORDS = ('ErrorComment', 'ErrorID', )
+
     def __init__(self):
         self.MessageID = None
         self.MessageIDBeingRespondedTo = None
@@ -2281,6 +2301,10 @@ class N_SET(object):
 
     DICOM Standard, Part 7, Section 10.1.3
     """
+    STATUS_OPTIONAL_KEYWORDS = (
+        'ErrorComment', 'ErrorID', 'AttributeIdentifierList'
+    )
+
     def __init__(self):
         self.MessageID = None
         self.MessageIDBeingRespondedTo = None
@@ -2591,8 +2615,11 @@ class N_ACTION(object):
         The reply to the action.
     Status : int
         The error or success notification of the operation.
-
     """
+    STATUS_OPTIONAL_KEYWORDS = (
+        'ErrorComment', 'ErrorID', 'AttributeIdentifierList'
+    )
+
     def __init__(self):
         self.MessageID = None
         self.MessageIDBeingRespondedTo = None
@@ -2902,8 +2929,9 @@ class N_CREATE(object):
     Status : int
         The error or success notification of the operation. It shall be
         one of the following values:
-
     """
+    STATUS_OPTIONAL_KEYWORDS = ('ErrorComment', 'ErrorID', )
+
     def __init__(self):
         self.MessageID = None
         self.MessageIDBeingRespondedTo = None
@@ -3124,6 +3152,8 @@ class N_DELETE(object):
 
     DICOM Standard Part 7, Sections 10.1.6 and 10.3.6.
     """
+    STATUS_OPTIONAL_KEYWORDS = ('ErrorComment', 'ErrorID', )
+
     def __init__(self):
         self.MessageID = None
         self.MessageIDBeingRespondedTo = None

--- a/pynetdicom3/presentation.py
+++ b/pynetdicom3/presentation.py
@@ -802,10 +802,7 @@ def build_context(abstract_syntax, transfer_syntax=DEFAULT_TRANSFER_SYNTAXES):
     -------
     presentation.PresentationContext
     """
-    if hasattr(abstract_syntax, 'uid'):
-        abstract_syntax = UID(abstract_syntax.uid)
-    else:
-        abstract_syntax = UID(abstract_syntax)
+    abstract_syntax = UID(abstract_syntax)
 
     # Allow single transfer syntax values for convenience
     if isinstance(transfer_syntax, str):

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -1,6 +1,5 @@
 """Generates the supported SOP Classes."""
 
-from collections import namedtuple
 import inspect
 import logging
 import sys
@@ -87,29 +86,31 @@ def uid_to_service_class(uid):
     return ServiceClass
 
 
-class SOPClass(namedtuple("SOPClass", ['uid', 'UID', 'service_class'])):
-    """A DICOM SOP Class.
+class SOPClass(UID):
+    """Extend pydicom's UID to include the corresponding Service Class."""
+    _service_class = None
 
-    Attributes
-    ----------
-    service_class : service_class.ServiceClass
-        The DICOM Service Class corresponding to the SOP Class.
-    uid : pydicom.uid.UID
-        The SOP Class UID.
-    UID : pydicom.uid.UID
-        The SOP Class UID.
-    """
-    pass
+    def __new__(cls, val):
+        if isinstance(val, SOPClass):
+            return val
+
+        return super(SOPClass, cls).__new__(cls, val)
+
+    def __getattribute__(self, name):
+        return super(SOPClass, self).__getattribute__(name)
+
+    @property
+    def service_class(self):
+        """Return the corresponding Service Class implementation."""
+        return self._service_class
 
 
 def _generate_sop_classes(sop_class_dict):
     """Generate the SOP Classes."""
     for name in sop_class_dict:
-        globals()[name] = SOPClass(
-            UID(sop_class_dict[name]),
-            UID(sop_class_dict[name]),
-            uid_to_service_class(sop_class_dict[name])
-        )
+        sop_class = SOPClass(sop_class_dict[name])
+        sop_class._service_class = uid_to_service_class(sop_class_dict[name])
+        globals()[name] = sop_class
 
 
 # Generate the various SOP classes
@@ -404,7 +405,10 @@ def uid_to_sop_class(uid):
     )
 
     for obj in members:
-        if hasattr(obj[1], 'uid') and obj[1].uid == uid:
+        if obj[1] == uid:
             return obj[1]
 
-    return SOPClass(uid, uid, ServiceClass)
+    sop_class = SOPClass(uid)
+    sop_class._service_class = ServiceClass
+
+    return sop_class

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -401,11 +401,11 @@ def uid_to_sop_class(uid):
     # Get a list of all the class members of the current module
     members = inspect.getmembers(
         sys.modules[__name__],
-        lambda mbr: isinstance(mbr, tuple)
+        lambda mbr: isinstance(mbr, str)
     )
 
     for obj in members:
-        if obj[1] == uid:
+        if hasattr(obj[1], 'service_class') and obj[1] == uid:
             return obj[1]
 
     sop_class = SOPClass(uid)

--- a/pynetdicom3/tests/dummy_c_scp.py
+++ b/pynetdicom3/tests/dummy_c_scp.py
@@ -8,7 +8,7 @@ import threading
 
 from pydicom import read_file
 from pydicom.dataset import Dataset
-from pydicom.uid import UID, ImplicitVRLittleEndian
+from pydicom.uid import UID, ImplicitVRLittleEndian, JPEG2000Lossless
 
 from pynetdicom3 import (
     AE,
@@ -234,7 +234,7 @@ class DummyStorageSCP(DummyBaseSCP):
         self.ae.add_supported_context(PatientStudyOnlyQueryRetrieveInformationModelMove)
         self.ae.add_supported_context(CTImageStorage, scp_role=True, scu_role=True)
         self.ae.add_supported_context(RTImageStorage)
-        self.ae.add_supported_context(MRImageStorage)
+        self.ae.add_supported_context(MRImageStorage, [ImplicitVRLittleEndian, JPEG2000Lossless])
         self.ae.add_supported_context(HangingProtocolStorage)
 
         DummyBaseSCP.__init__(self)
@@ -316,6 +316,8 @@ class DummyGetSCP(DummyBaseSCP):
         DummyBaseSCP.__init__(self)
         self.statuses = [0x0000]
         ds = Dataset()
+        ds.file_meta = Dataset()
+        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.PatientName = 'Test'
         ds.SOPClassUID = CTImageStorage.UID
         ds.SOPInstanceUID = '1.2.3.4'
@@ -368,6 +370,8 @@ class DummyMoveSCP(DummyBaseSCP):
         self.statuses = [0x0000]
         self.store_status = 0x0000
         ds = Dataset()
+        ds.file_meta = Dataset()
+        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.PatientName = 'Test'
         ds.SOPClassUID = CTImageStorage.UID
         ds.SOPInstanceUID = '1.2.3.4'

--- a/pynetdicom3/tests/dummy_c_scp.py
+++ b/pynetdicom3/tests/dummy_c_scp.py
@@ -319,7 +319,7 @@ class DummyGetSCP(DummyBaseSCP):
         ds.file_meta = Dataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.PatientName = 'Test'
-        ds.SOPClassUID = CTImageStorage.UID
+        ds.SOPClassUID = CTImageStorage
         ds.SOPInstanceUID = '1.2.3.4'
         self.datasets = [ds]
         self.no_suboperations = 1
@@ -373,7 +373,7 @@ class DummyMoveSCP(DummyBaseSCP):
         ds.file_meta = Dataset()
         ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         ds.PatientName = 'Test'
-        ds.SOPClassUID = CTImageStorage.UID
+        ds.SOPClassUID = CTImageStorage
         ds.SOPInstanceUID = '1.2.3.4'
         self.datasets = [ds]
         self.no_suboperations = 1

--- a/pynetdicom3/tests/dummy_n_scp.py
+++ b/pynetdicom3/tests/dummy_n_scp.py
@@ -35,7 +35,7 @@ class DummyEventReportSCP(DummyBaseSCP):
         self.status = 0x0000
         ds = Dataset()
         ds.PatientName = 'Test'
-        ds.SOPClassUID = PrintJobSOPClass.UID
+        ds.SOPClassUID = PrintJobSOPClass
         ds.SOPInstanceUID = '1.2.3.4'
         self.dataset = ds
 
@@ -60,7 +60,7 @@ class DummyGetSCP(DummyBaseSCP):
         self.status = 0x0000
         ds = Dataset()
         ds.PatientName = 'Test'
-        ds.SOPClassUID = DisplaySystemSOPClass.UID
+        ds.SOPClassUID = DisplaySystemSOPClass
         ds.SOPInstanceUID = '1.2.3.4'
         self.dataset = ds
 
@@ -85,7 +85,7 @@ class DummySetSCP(DummyBaseSCP):
         self.status = 0x0000
         ds = Dataset()
         ds.PatientName = 'Test'
-        ds.SOPClassUID = PrintJobSOPClass.UID
+        ds.SOPClassUID = PrintJobSOPClass
         ds.SOPInstanceUID = '1.2.3.4'
         self.dataset = ds
 
@@ -109,7 +109,7 @@ class DummyActionSCP(DummyBaseSCP):
         self.status = 0x0000
         ds = Dataset()
         ds.PatientName = 'Test'
-        ds.SOPClassUID = PrintJobSOPClass.UID
+        ds.SOPClassUID = PrintJobSOPClass
         ds.SOPInstanceUID = '1.2.3.4'
         self.dataset = ds
 
@@ -133,7 +133,7 @@ class DummyCreateSCP(DummyBaseSCP):
         self.status = 0x0000
         ds = Dataset()
         ds.PatientName = 'Test'
-        ds.SOPClassUID = PrintJobSOPClass.UID
+        ds.SOPClassUID = PrintJobSOPClass
         ds.SOPInstanceUID = '1.2.3.4'
         self.dataset = ds
 

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -23,6 +23,7 @@ from pydicom.uid import (
     ExplicitVRLittleEndian,
     JPEGBaseline,
     JPEG2000,
+    JPEG2000Lossless,
 )
 
 from pynetdicom3 import AE, VerificationPresentationContexts
@@ -86,6 +87,7 @@ LOGGER.setLevel(logging.CRITICAL)
 TEST_DS_DIR = os.path.join(os.path.dirname(__file__), 'dicom_files')
 BIG_DATASET = dcmread(os.path.join(TEST_DS_DIR, 'RTImageStorage.dcm')) # 2.1 M
 DATASET = dcmread(os.path.join(TEST_DS_DIR, 'CTImageStorage.dcm'))
+# JPEG2000Lossless UID
 COMP_DATASET = dcmread(os.path.join(TEST_DS_DIR, 'MRImageStorage_JPG2000_Lossless.dcm'))
 
 
@@ -141,6 +143,7 @@ class TestCStoreSCP(object):
         req.AffectedSOPClassUID = DATASET.SOPClassUID
         req.AffectedSOPInstanceUID = DATASET.SOPInstanceUID
         req.Priority = 1
+        req._context_id = 1
 
         bytestream = encode(DATASET, True, True)
         req.DataSet = BytesIO(bytestream)
@@ -183,6 +186,7 @@ class TestCStoreSCP(object):
         req.AffectedSOPClassUID = DATASET.SOPClassUID
         req.AffectedSOPInstanceUID = DATASET.SOPInstanceUID
         req.Priority = 1
+        req._context_id = 1
 
         bytestream = encode(DATASET, True, True)
         req.DataSet = BytesIO(bytestream)
@@ -221,6 +225,7 @@ class TestCStoreSCP(object):
         req.AffectedSOPClassUID = DATASET.SOPClassUID
         req.AffectedSOPInstanceUID = DATASET.SOPInstanceUID
         req.Priority = 1
+        req._context_id = 1
 
         bytestream = encode(DATASET, True, True)
         req.DataSet = BytesIO(bytestream)
@@ -260,6 +265,7 @@ class TestCStoreSCP(object):
         req.AffectedSOPClassUID = DATASET.SOPClassUID
         req.AffectedSOPInstanceUID = DATASET.SOPInstanceUID
         req.Priority = 1
+        req._context_id = 1
 
         bytestream = encode(DATASET, True, True)
         req.DataSet = BytesIO(bytestream)
@@ -297,6 +303,7 @@ class TestCStoreSCP(object):
         req.AffectedSOPClassUID = DATASET.SOPClassUID
         req.AffectedSOPInstanceUID = DATASET.SOPInstanceUID
         req.Priority = 1
+        req._context_id = 1
 
         bytestream = encode(DATASET, True, True)
         req.DataSet = BytesIO(bytestream)
@@ -335,6 +342,7 @@ class TestCStoreSCP(object):
         req.AffectedSOPClassUID = DATASET.SOPClassUID
         req.AffectedSOPInstanceUID = DATASET.SOPInstanceUID
         req.Priority = 1
+        req._context_id = 1
 
         bytestream = encode(DATASET, True, True)
         req.DataSet = BytesIO(bytestream)
@@ -1083,11 +1091,13 @@ class TestAssociationSendCStore(object):
         self.scp = DummyStorageSCP()
         self.scp.start()
         ae = AE()
-        ae.add_requested_context(MRImageStorage)
+        ae.add_requested_context(MRImageStorage, JPEG2000Lossless)
         ae.acse_timeout = 5
         ae.dimse_timeout = 5
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
+        for cx in assoc.accepted_contexts:
+            print(cx)
         result = assoc.send_c_store(COMP_DATASET)
         assert result.Status == 0x0000
         assoc.release()
@@ -1604,6 +1614,8 @@ class TestAssociationSendCGet(object):
         self.ds.QueryRetrieveLevel = "PATIENT"
 
         self.good = Dataset()
+        self.good.file_meta = Dataset()
+        self.good.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         self.good.SOPClassUID = CTImageStorage.uid
         self.good.SOPInstanceUID = '1.1.1'
         self.good.PatientName = 'Test'
@@ -2074,6 +2086,8 @@ class TestAssociationSendCMove(object):
         self.ds.QueryRetrieveLevel = "PATIENT"
 
         self.good = Dataset()
+        self.good.file_meta = Dataset()
+        self.good.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         self.good.SOPClassUID = CTImageStorage.uid
         self.good.SOPInstanceUID = '1.1.1'
         self.good.PatientName = 'Test'

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -130,7 +130,7 @@ class TestCStoreSCP(object):
         ae.on_c_store = self.scp.on_c_store
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -173,7 +173,7 @@ class TestCStoreSCP(object):
         ae.on_c_store = self.scp.on_c_store
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -212,7 +212,7 @@ class TestCStoreSCP(object):
         ae.on_c_store = self.scp.on_c_store
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -252,7 +252,7 @@ class TestCStoreSCP(object):
         ae.on_c_store = self.scp.on_c_store
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -290,7 +290,7 @@ class TestCStoreSCP(object):
         ae.on_c_store = self.scp.on_c_store
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -325,7 +325,7 @@ class TestCStoreSCP(object):
         ae.add_requested_context(RTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1616,7 +1616,7 @@ class TestAssociationSendCGet(object):
         self.good = Dataset()
         self.good.file_meta = Dataset()
         self.good.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
-        self.good.SOPClassUID = CTImageStorage.uid
+        self.good.SOPClassUID = CTImageStorage
         self.good.SOPInstanceUID = '1.1.1'
         self.good.PatientName = 'Test'
 
@@ -1668,7 +1668,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = True
         role.scp_role = False
 
@@ -1815,7 +1815,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1850,7 +1850,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1890,7 +1890,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = True
         role.scp_role = False
 
@@ -1930,7 +1930,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = True
         role.scp_role = False
 
@@ -1988,7 +1988,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = True
         role.scp_role = False
 
@@ -2026,7 +2026,7 @@ class TestAssociationSendCGet(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = True
         role.scp_role = False
 
@@ -2088,7 +2088,7 @@ class TestAssociationSendCMove(object):
         self.good = Dataset()
         self.good.file_meta = Dataset()
         self.good.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
-        self.good.SOPClassUID = CTImageStorage.uid
+        self.good.SOPClassUID = CTImageStorage
         self.good.SOPInstanceUID = '1.1.1'
         self.good.PatientName = 'Test'
 
@@ -2636,7 +2636,7 @@ class TestGetValidContext(object):
             r"accepted by the peer for the SOP Class 'CT Image Storage'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid, '', 'scu', context_id=1)
+            assoc._get_valid_context(CTImageStorage, '', 'scu', context_id=1)
 
         assoc.release()
         assert assoc.is_released
@@ -2661,21 +2661,21 @@ class TestGetValidContext(object):
         assert assoc.is_established
 
         # Uncompressed accepted, different uncompressed sent
-        cx = assoc._get_valid_context(CTImageStorage.uid,
+        cx = assoc._get_valid_context(CTImageStorage,
                                       '',
                                       'scu',
                                       context_id=3)
         assert cx.context_id == 3
-        assert cx.abstract_syntax == CTImageStorage.uid
+        assert cx.abstract_syntax == CTImageStorage
         assert cx.transfer_syntax[0] == ImplicitVRLittleEndian
         assert cx.as_scu is True
 
-        cx = assoc._get_valid_context(CTImageStorage.uid,
+        cx = assoc._get_valid_context(CTImageStorage,
                                       '',
                                       'scu',
                                       context_id=5)
         assert cx.context_id == 5
-        assert cx.abstract_syntax == CTImageStorage.uid
+        assert cx.abstract_syntax == CTImageStorage
         assert cx.transfer_syntax[0] == JPEGBaseline
         assert cx.as_scu is True
 
@@ -2714,7 +2714,7 @@ class TestGetValidContext(object):
 
         # Compressed (JPEGBaseline) accepted, uncompressed sent
         # Confirm otherwise OK
-        cx = assoc._get_valid_context(CTImageStorage.uid,
+        cx = assoc._get_valid_context(CTImageStorage,
                                       JPEGBaseline,
                                       'scu',
                                       context_id=3)
@@ -2727,7 +2727,7 @@ class TestGetValidContext(object):
             r"with a transfer syntax of 'Implicit VR Little Endian'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      ImplicitVRLittleEndian,
                                      'scu',
                                      context_id=3)
@@ -2739,7 +2739,7 @@ class TestGetValidContext(object):
             r"with a transfer syntax of 'JPEG 2000 Image Compression'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      JPEG2000,
                                      'scu',
                                      context_id=3)
@@ -2801,7 +2801,7 @@ class TestGetValidContext(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -2811,7 +2811,7 @@ class TestGetValidContext(object):
         assert assoc.is_established
 
         # Confirm matching otherwise OK
-        cx = assoc._get_valid_context(CTImageStorage.uid,
+        cx = assoc._get_valid_context(CTImageStorage,
                                       '',
                                       'scp',
                                       context_id=3)
@@ -2824,7 +2824,7 @@ class TestGetValidContext(object):
             r"accepted by the peer for the SOP Class 'CT Image Storage'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      '',
                                      'scu',
                                      context_id=3)
@@ -2836,7 +2836,7 @@ class TestGetValidContext(object):
             r"with a transfer syntax of 'Implicit VR Little Endian'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      ImplicitVRLittleEndian,
                                      'scu',
                                      context_id=3)
@@ -2854,14 +2854,14 @@ class TestGetValidContext(object):
         assert assoc.is_established
 
         # Test otherwise OK
-        assoc._get_valid_context(VerificationSOPClass.uid, '', 'scu')
+        assoc._get_valid_context(VerificationSOPClass, '', 'scu')
 
         msg = (
             r"No suitable presentation context for the SCU role has been "
             r"accepted by the peer for the SOP Class 'CT Image Storage'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid, '', 'scu')
+            assoc._get_valid_context(CTImageStorage, '', 'scu')
 
         assoc.release()
         assert assoc.is_released
@@ -2885,7 +2885,7 @@ class TestGetValidContext(object):
                                       ExplicitVRLittleEndian,
                                       'scu')
         assert cx.context_id == 1
-        assert cx.abstract_syntax == VerificationSOPClass.uid
+        assert cx.abstract_syntax == VerificationSOPClass
         assert cx.transfer_syntax[0] == ImplicitVRLittleEndian
         assert cx.as_scu is True
 
@@ -2918,7 +2918,7 @@ class TestGetValidContext(object):
 
         # Compressed (JPEGBaseline) accepted, uncompressed sent
         # Confirm otherwise OK
-        cx = assoc._get_valid_context(CTImageStorage.uid, JPEGBaseline, 'scu')
+        cx = assoc._get_valid_context(CTImageStorage, JPEGBaseline, 'scu')
         assert cx.context_id == 3
         assert cx.transfer_syntax[0] == JPEGBaseline
 
@@ -2928,7 +2928,7 @@ class TestGetValidContext(object):
             r"with a transfer syntax of 'Implicit VR Little Endian'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      ImplicitVRLittleEndian,
                                      'scu')
 
@@ -2939,7 +2939,7 @@ class TestGetValidContext(object):
             r"with a transfer syntax of 'JPEG 2000 Image Compression'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid, JPEG2000, 'scu')
+            assoc._get_valid_context(CTImageStorage, JPEG2000, 'scu')
 
         assoc.release()
         assert assoc.is_released
@@ -2991,7 +2991,7 @@ class TestGetValidContext(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -3001,7 +3001,7 @@ class TestGetValidContext(object):
         assert assoc.is_established
 
         # Confirm matching otherwise OK
-        cx = assoc._get_valid_context(CTImageStorage.uid, '', 'scp')
+        cx = assoc._get_valid_context(CTImageStorage, '', 'scp')
         assert cx.context_id == 3
         assert cx.as_scp is True
 
@@ -3011,7 +3011,7 @@ class TestGetValidContext(object):
             r"accepted by the peer for the SOP Class 'CT Image Storage'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      '',
                                      'scu')
 
@@ -3022,6 +3022,6 @@ class TestGetValidContext(object):
             r"with a transfer syntax of 'Implicit VR Little Endian'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc._get_valid_context(CTImageStorage.uid,
+            assoc._get_valid_context(CTImageStorage,
                                      ImplicitVRLittleEndian,
                                      'scu')

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -81,8 +81,8 @@ from .dummy_c_scp import (
 )
 
 LOGGER = logging.getLogger('pynetdicom3')
-#LOGGER.setLevel(logging.CRITICAL)
-LOGGER.setLevel(logging.DEBUG)
+LOGGER.setLevel(logging.CRITICAL)
+#LOGGER.setLevel(logging.DEBUG)
 
 TEST_DS_DIR = os.path.join(os.path.dirname(__file__), 'dicom_files')
 BIG_DATASET = dcmread(os.path.join(TEST_DS_DIR, 'RTImageStorage.dcm')) # 2.1 M
@@ -1723,7 +1723,7 @@ class TestAssociationSendCFind(object):
 
             def receive_msg(*args, **kwargs):
                 rsp = C_FIND()
-                rsp.Status = 0xC000
+                rsp.Status = 0xFF00
                 rsp.MessageIDBeingRespondedTo = 1
                 rsp.Identifier = BytesIO(b'\x08\x00\x01\x00\x04\x00\x00\x00\x00\x08\x00\x49')
                 return rsp, 1
@@ -1734,7 +1734,7 @@ class TestAssociationSendCFind(object):
         results = assoc.send_c_find(self.ds, query_model='P')
         status, ds = next(results)
 
-        assert status.Status == 0xC000
+        assert status.Status == 0xFF00
         assert ds is None
 
         self.scp.stop()

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -1060,7 +1060,6 @@ class TestAssociationSendCEcho(object):
         assert len(assoc.rejected_contexts) == 1
         cx = assoc.rejected_contexts[0]
         assert cx.abstract_syntax == CTImageStorage
-        assert result.Status == 0x0000
         assoc.release()
         assert assoc.is_released
         self.scp.stop()

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -2584,3 +2584,9 @@ class TestAssociationCallbacks(object):
         assoc.release()
         assert assoc.is_released
         self.scp.stop()
+
+
+class TestGetValidContext(object):
+    """Tests for Association._get_valid_context."""
+    def setup(self):
+        pass

--- a/pynetdicom3/tests/test_assoc_n.py
+++ b/pynetdicom3/tests/test_assoc_n.py
@@ -118,8 +118,8 @@ class TestAssociationSendNEventReport(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         msg = (
-            r"No accepted Presentation Context for the SOP Class "
-            r"UID '1.2.840.10008.1.1'"
+            r"No suitable presentation context for the SCU role has been "
+            r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_event_report(
@@ -428,8 +428,8 @@ class TestAssociationSendNGet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         msg = (
-            r"No accepted Presentation Context for the SOP Class "
-            r"UID '1.2.840.10008.1.1'"
+            r"No suitable presentation context for the SCU role has been "
+            r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_get(None, VerificationSOPClass.uid, None)
@@ -723,8 +723,8 @@ class TestAssociationSendNSet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         msg = (
-            r"No accepted Presentation Context for the SOP Class "
-            r"UID '1.2.840.10008.1.1'"
+            r"No suitable presentation context for the SCU role has been "
+            r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_set(None, VerificationSOPClass.uid, None)
@@ -1059,8 +1059,8 @@ class TestAssociationSendNAction(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         msg = (
-            r"No accepted Presentation Context for the SOP Class "
-            r"UID '1.2.840.10008.1.1'"
+            r"No suitable presentation context for the SCU role has been "
+            r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_action(None, 1, VerificationSOPClass.uid, None)
@@ -1393,8 +1393,8 @@ class TestAssociationSendNCreate(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         msg = (
-            r"No accepted Presentation Context for the SOP Class "
-            r"UID '1.2.840.10008.1.1'"
+            r"No suitable presentation context for the SCU role has been "
+            r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_create(None, VerificationSOPClass.uid, None)
@@ -1723,8 +1723,8 @@ class TestAssociationSendNDelete(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         msg = (
-            r"No accepted Presentation Context for the SOP Class "
-            r"UID '1.2.840.10008.1.1'"
+            r"No suitable presentation context for the SCU role has been "
+            r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_delete(VerificationSOPClass.uid, None)

--- a/pynetdicom3/tests/test_assoc_n.py
+++ b/pynetdicom3/tests/test_assoc_n.py
@@ -123,7 +123,7 @@ class TestAssociationSendNEventReport(object):
         )
         with pytest.raises(ValueError, match=msg):
             assoc.send_n_event_report(
-                None, None, VerificationSOPClass.uid, None
+                None, None, VerificationSOPClass, None
             )
         assoc.release()
         assert assoc.is_released
@@ -143,7 +143,7 @@ class TestAssociationSendNEventReport(object):
         ds.PerimeterValue = b'\x00\x01'
         msg = r"Failed to encode the supplied dataset"
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_event_report(ds, 1, PrintJobSOPClass.uid, '1.2.3')
+            assoc.send_n_event_report(ds, 1, PrintJobSOPClass, '1.2.3')
         assoc.release()
         assert assoc.is_released
 
@@ -169,7 +169,7 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
 
         assert status == Dataset()
@@ -200,7 +200,7 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status == Dataset()
         assert ds is None
@@ -223,7 +223,7 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0112
         assert ds is None
@@ -246,13 +246,13 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0116
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -272,13 +272,13 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0000
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -299,7 +299,7 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0xFFF0
         assert ds is None
@@ -341,7 +341,7 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
 
         assert status.Status == 0x0110
@@ -369,7 +369,7 @@ class TestAssociationSendNEventReport(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_event_report(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0xFFF0
         assert status.ErrorComment == 'Some comment'
@@ -432,7 +432,7 @@ class TestAssociationSendNGet(object):
             r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_get(None, VerificationSOPClass.uid, None)
+            assoc.send_n_get(None, VerificationSOPClass, None)
         assoc.release()
         assert assoc.is_released
         self.scp.stop()
@@ -459,7 +459,7 @@ class TestAssociationSendNGet(object):
         assoc.dimse = DummyDIMSE()
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
 
         assert status == Dataset()
@@ -488,7 +488,7 @@ class TestAssociationSendNGet(object):
         assoc.dimse = DummyDIMSE()
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status == Dataset()
         assert ds is None
@@ -508,7 +508,7 @@ class TestAssociationSendNGet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0, 0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0112
         assert ds is None
@@ -528,13 +528,13 @@ class TestAssociationSendNGet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0116
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == DisplaySystemSOPClass.UID
+        assert ds.SOPClassUID == DisplaySystemSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -551,13 +551,13 @@ class TestAssociationSendNGet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == DisplaySystemSOPClass.UID
+        assert ds.SOPClassUID == DisplaySystemSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -575,7 +575,7 @@ class TestAssociationSendNGet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assert ds is None
@@ -597,6 +597,7 @@ class TestAssociationSendNGet(object):
             is_valid_response = True
             AttributeList = None
             Status = 0x0000
+            STATUS_OPTIONAL_KEYWORDS = []
 
         class DummyDIMSE():
             def send_msg(*args, **kwargs):
@@ -613,7 +614,7 @@ class TestAssociationSendNGet(object):
         assoc.dimse = DummyDIMSE()
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
 
         assert status.Status == 0x0110
@@ -636,7 +637,7 @@ class TestAssociationSendNGet(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assert status.ErrorComment == 'Some comment'
@@ -727,7 +728,7 @@ class TestAssociationSendNSet(object):
             r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_set(None, VerificationSOPClass.uid, None)
+            assoc.send_n_set(None, VerificationSOPClass, None)
         assoc.release()
         assert assoc.is_released
         self.scp.stop()
@@ -746,7 +747,7 @@ class TestAssociationSendNSet(object):
         mod_list.PerimeterValue = b'\x00\x01'
         msg = r"Failed to encode the supplied Dataset"
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_set(mod_list, PrintJobSOPClass.uid, '1.2.3')
+            assoc.send_n_set(mod_list, PrintJobSOPClass, '1.2.3')
         assoc.release()
         assert assoc.is_released
 
@@ -772,7 +773,7 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
 
         assert status == Dataset()
@@ -803,7 +804,7 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status == Dataset()
         assert ds is None
@@ -826,7 +827,7 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0112
         assert ds is None
@@ -849,13 +850,13 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0116
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -875,13 +876,13 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -902,7 +903,7 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assert ds is None
@@ -925,6 +926,7 @@ class TestAssociationSendNSet(object):
             is_valid_response = True
             ModificationList = None
             Status = 0x0000
+            STATUS_OPTIONAL_KEYWORDS = []
 
         class DummyDIMSE():
             def send_msg(*args, **kwargs):
@@ -943,7 +945,7 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
 
         assert status.Status == 0x0110
@@ -970,7 +972,7 @@ class TestAssociationSendNSet(object):
         mod_list = Dataset()
         mod_list.PatientName = 'Test^test'
         status, ds = assoc.send_n_set(mod_list,
-                                      PrintJobSOPClass.uid,
+                                      PrintJobSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assert status.ErrorComment == 'Some comment'
@@ -1063,7 +1065,7 @@ class TestAssociationSendNAction(object):
             r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_action(None, 1, VerificationSOPClass.uid, None)
+            assoc.send_n_action(None, 1, VerificationSOPClass, None)
         assoc.release()
         assert assoc.is_released
         self.scp.stop()
@@ -1082,7 +1084,7 @@ class TestAssociationSendNAction(object):
         ds.PerimeterValue = b'\x00\x01'
         msg = r"Failed to encode the supplied Dataset"
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_action(ds, 1, PrintJobSOPClass.uid, '1.2.3')
+            assoc.send_n_action(ds, 1, PrintJobSOPClass, '1.2.3')
         assoc.release()
         assert assoc.is_released
 
@@ -1108,7 +1110,7 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
 
         assert status == Dataset()
@@ -1139,7 +1141,7 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status == Dataset()
         assert ds is None
@@ -1162,7 +1164,7 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0112
         assert ds is None
@@ -1185,13 +1187,13 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0116
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -1211,13 +1213,13 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0000
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -1238,7 +1240,7 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0xFFF0
         assert ds is None
@@ -1261,6 +1263,7 @@ class TestAssociationSendNAction(object):
             is_valid_response = True
             ModificationList = None
             Status = 0x0000
+            STATUS_OPTIONAL_KEYWORDS = []
 
         class DummyDIMSE():
             def send_msg(*args, **kwargs):
@@ -1279,7 +1282,7 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
 
         assert status.Status == 0x0110
@@ -1305,7 +1308,7 @@ class TestAssociationSendNAction(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_action(
-            ds, 1, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, 1, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0xFFF0
         assert status.ErrorComment == 'Some comment'
@@ -1397,7 +1400,7 @@ class TestAssociationSendNCreate(object):
             r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_create(None, VerificationSOPClass.uid, None)
+            assoc.send_n_create(None, VerificationSOPClass, None)
         assoc.release()
         assert assoc.is_released
         self.scp.stop()
@@ -1416,7 +1419,7 @@ class TestAssociationSendNCreate(object):
         ds.PerimeterValue = b'\x00\x01'
         msg = r"Failed to encode the supplied Dataset"
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_create(ds, PrintJobSOPClass.uid, '1.2.3')
+            assoc.send_n_create(ds, PrintJobSOPClass, '1.2.3')
         assoc.release()
         assert assoc.is_released
 
@@ -1442,7 +1445,7 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
 
         assert status == Dataset()
@@ -1473,7 +1476,7 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status == Dataset()
         assert ds is None
@@ -1496,7 +1499,7 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0112
         assert ds is None
@@ -1519,13 +1522,13 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0116
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -1545,13 +1548,13 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0x0000
         assert ds is not None
         assert isinstance(ds, Dataset)
         assert ds.PatientName == 'Test'
-        assert ds.SOPClassUID == PrintJobSOPClass.UID
+        assert ds.SOPClassUID == PrintJobSOPClass
         assert ds.SOPInstanceUID == '1.2.3.4'
         assoc.release()
         assert assoc.is_released
@@ -1572,7 +1575,7 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0xFFF0
         assert ds is None
@@ -1595,6 +1598,7 @@ class TestAssociationSendNCreate(object):
             is_valid_response = True
             ModificationList = None
             Status = 0x0000
+            STATUS_OPTIONAL_KEYWORDS = []
 
         class DummyDIMSE():
             def send_msg(*args, **kwargs):
@@ -1613,7 +1617,7 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
 
         assert status.Status == 0x0110
@@ -1639,7 +1643,7 @@ class TestAssociationSendNCreate(object):
         ds = Dataset()
         ds.PatientName = 'Test^test'
         status, ds = assoc.send_n_create(
-            ds, PrintJobSOPClass.uid, '1.2.840.10008.5.1.1.40.1'
+            ds, PrintJobSOPClass, '1.2.840.10008.5.1.1.40.1'
         )
         assert status.Status == 0xFFF0
         assert status.ErrorComment == 'Some comment'
@@ -1727,7 +1731,7 @@ class TestAssociationSendNDelete(object):
             r"accepted by the peer for the SOP Class 'Verification SOP Class'"
         )
         with pytest.raises(ValueError, match=msg):
-            assoc.send_n_delete(VerificationSOPClass.uid, None)
+            assoc.send_n_delete(VerificationSOPClass, None)
         assoc.release()
         assert assoc.is_released
         self.scp.stop()
@@ -1749,7 +1753,7 @@ class TestAssociationSendNDelete(object):
 
         assoc.dimse = DummyDIMSE()
         assert assoc.is_established
-        status = assoc.send_n_delete(PrintJobSOPClass.uid,
+        status = assoc.send_n_delete(PrintJobSOPClass,
                                      '1.2.840.10008.5.1.1.40.1')
 
         assert status == Dataset()
@@ -1776,7 +1780,7 @@ class TestAssociationSendNDelete(object):
 
         assoc.dimse = DummyDIMSE()
         assert assoc.is_established
-        status = assoc.send_n_delete(PrintJobSOPClass.uid,
+        status = assoc.send_n_delete(PrintJobSOPClass,
                                      '1.2.840.10008.5.1.1.40.1')
         assert status == Dataset()
         assert assoc.is_aborted
@@ -1795,7 +1799,7 @@ class TestAssociationSendNDelete(object):
         ae.dimse_timeout = 5
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
-        status = assoc.send_n_delete(PrintJobSOPClass.uid,
+        status = assoc.send_n_delete(PrintJobSOPClass,
                                      '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0112
         assoc.release()
@@ -1814,7 +1818,7 @@ class TestAssociationSendNDelete(object):
         assoc = ae.associate('localhost', 11112)
 
         assert assoc.is_established
-        status = assoc.send_n_delete(PrintJobSOPClass.uid,
+        status = assoc.send_n_delete(PrintJobSOPClass,
                                      '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assoc.release()
@@ -1833,7 +1837,7 @@ class TestAssociationSendNDelete(object):
         ae.dimse_timeout = 5
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
-        status = assoc.send_n_delete(PrintJobSOPClass.uid,
+        status = assoc.send_n_delete(PrintJobSOPClass,
                                      '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assoc.release()
@@ -1855,7 +1859,7 @@ class TestAssociationSendNDelete(object):
         ae.dimse_timeout = 5
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
-        status = assoc.send_n_delete(PrintJobSOPClass.uid,
+        status = assoc.send_n_delete(PrintJobSOPClass,
                                      '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assert status.ErrorComment == 'Some comment'

--- a/pynetdicom3/tests/test_presentation.py
+++ b/pynetdicom3/tests/test_presentation.py
@@ -948,7 +948,7 @@ class TestNegotiateAsRequestorWithRoleSelection(object):
         context_a.context_id = 1
         context_b = build_context(CTImageStorage)
         context_b.context_id = 3
-        rq_roles = {CTImageStorage.uid : (False, True)}
+        rq_roles = {CTImageStorage : (False, True)}
         rq_contexts = [context_a, context_b]
 
         # Acceptor
@@ -970,11 +970,11 @@ class TestNegotiateAsRequestorWithRoleSelection(object):
         rq_contexts[1].scp_role = True
         result = negotiate_as_requestor(rq_contexts, result, ac_roles)
 
-        assert result[0].abstract_syntax == CompositeInstanceRetrieveWithoutBulkDataGet.uid
+        assert result[0].abstract_syntax == CompositeInstanceRetrieveWithoutBulkDataGet
         assert result[0].as_scu
         assert not result[0].as_scp
 
-        assert result[1].abstract_syntax == CTImageStorage.uid
+        assert result[1].abstract_syntax == CTImageStorage
         assert not result[1].as_scu
         assert result[1].as_scp
 
@@ -983,7 +983,7 @@ class TestNegotiateAsRequestorWithRoleSelection(object):
         # Requestor
         context_a = build_context(CTImageStorage)
         context_a.context_id = 3
-        rq_roles = {CTImageStorage.uid : (True, False)}
+        rq_roles = {CTImageStorage : (True, False)}
         rq_contexts = [context_a]
 
         # Acceptor
@@ -1015,7 +1015,7 @@ class TestNegotiateAsRequestorWithRoleSelection(object):
         # Requestor
         context_a = build_context(CTImageStorage)
         context_a.context_id = 3
-        rq_roles = {CTImageStorage.uid : (False, True)}
+        rq_roles = {CTImageStorage : (False, True)}
         rq_contexts = [context_a]
 
         # Acceptor

--- a/pynetdicom3/tests/test_service_display.py
+++ b/pynetdicom3/tests/test_service_display.py
@@ -53,7 +53,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0001
         assert ds.PatientName == 'Test'
@@ -75,7 +75,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0001
         assert status.ErrorComment == 'Test'
@@ -96,7 +96,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assert not 'ErrorComment' in status
@@ -114,7 +114,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xFFF0
         assert ds is None
@@ -132,7 +132,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0xC002
         assert ds is None
@@ -152,7 +152,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0110
         assert ds is None
@@ -171,7 +171,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assert 'PatientName' in ds
@@ -179,7 +179,7 @@ class TestDisplayServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == DisplaySystemSOPClass.UID
+        assert self.scp.context.abstract_syntax == DisplaySystemSOPClass
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()
@@ -196,7 +196,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0,0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assert 'PatientName' in ds
@@ -211,7 +211,7 @@ class TestDisplayServiceClass(object):
         assert self.scp.info['acceptor']['address'] == '127.0.0.1'
         assert self.scp.info['acceptor']['ae_title'] == b'PYNETDICOM      '
         assert self.scp.info['parameters']['message_id'] == 1
-        assert self.scp.info['parameters']['requested_sop_class_uid'] == DisplaySystemSOPClass.uid
+        assert self.scp.info['parameters']['requested_sop_class_uid'] == DisplaySystemSOPClass
         assert self.scp.info['parameters']['requested_sop_instance_uid'] == '1.2.840.10008.5.1.1.40.1'
 
         self.scp.stop()
@@ -228,7 +228,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0, 0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0000
         assert 'PatientName' in ds
@@ -253,7 +253,7 @@ class TestDisplayServiceClass(object):
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
         status, ds = assoc.send_n_get([(0x7fe0, 0x0010)],
-                                      DisplaySystemSOPClass.uid,
+                                      DisplaySystemSOPClass,
                                       '1.2.840.10008.5.1.1.40.1')
         assert status.Status == 0x0110
         assert ds is None

--- a/pynetdicom3/tests/test_service_non_patient.py
+++ b/pynetdicom3/tests/test_service_non_patient.py
@@ -29,7 +29,7 @@ LOGGER.setLevel(logging.CRITICAL)
 
 TEST_DS_DIR = os.path.join(os.path.dirname(__file__), 'dicom_files')
 DATASET = dcmread(os.path.join(TEST_DS_DIR, 'CTImageStorage.dcm'))
-DATASET.SOPClassUID = HangingProtocolStorage.uid
+DATASET.SOPClassUID = HangingProtocolStorage
 
 
 class TestNonPatientObjectStorageServiceClass(object):
@@ -196,7 +196,7 @@ class TestNonPatientObjectStorageServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == HangingProtocolStorage.UID
+        assert self.scp.context.abstract_syntax == HangingProtocolStorage
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()

--- a/pynetdicom3/tests/test_service_qr.py
+++ b/pynetdicom3/tests/test_service_qr.py
@@ -104,7 +104,7 @@ class TestQRFindServiceClass(object):
 
         req = C_FIND()
         req.MessageID = 1
-        req.AffectedSOPClassUID = PatientRootQueryRetrieveInformationModelFind.uid
+        req.AffectedSOPClassUID = PatientRootQueryRetrieveInformationModelFind
         req.Priority = 2
         req.Identifier = BytesIO(b'\x08\x00\x01\x00\x04\x00\x00\x00\x00\x08\x00\x49')
         assoc.dimse.send_msg(req, 1)
@@ -476,7 +476,7 @@ class TestQRFindServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == PatientRootQueryRetrieveInformationModelFind.uid
+        assert self.scp.context.abstract_syntax == PatientRootQueryRetrieveInformationModelFind
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()
@@ -526,7 +526,7 @@ class TestQRGetServiceClass(object):
         self.ds = Dataset()
         self.ds.file_meta = Dataset()
         self.ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
-        self.ds.SOPClassUID = CTImageStorage.uid
+        self.ds.SOPClassUID = CTImageStorage
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'
 
@@ -564,7 +564,7 @@ class TestQRGetServiceClass(object):
 
         req = C_GET()
         req.MessageID = 1
-        req.AffectedSOPClassUID = PatientRootQueryRetrieveInformationModelGet.uid
+        req.AffectedSOPClassUID = PatientRootQueryRetrieveInformationModelGet
         req.Priority = 2
         req.Identifier = BytesIO(b'\x08\x00\x01\x00\x04\x00\x00\x00\x00\x08\x00\x49')
         assoc.dimse.send_msg(req, 1)
@@ -588,7 +588,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -621,7 +621,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -658,7 +658,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -695,7 +695,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -729,7 +729,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -759,7 +759,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -789,7 +789,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -820,7 +820,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -851,7 +851,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -892,7 +892,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -935,7 +935,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -973,7 +973,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1013,7 +1013,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1056,7 +1056,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1099,7 +1099,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1139,7 +1139,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1179,7 +1179,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1219,7 +1219,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1265,7 +1265,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1313,7 +1313,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1361,7 +1361,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1401,7 +1401,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1441,7 +1441,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1481,7 +1481,7 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
@@ -1520,13 +1520,13 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage, '1.2.840.10008.1.2.1')
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
         def on_c_store(ds, context, assoc_info):
             assert context.context_id == 3
-            assert context.abstract_syntax == CTImageStorage.uid
+            assert context.abstract_syntax == CTImageStorage
             assert context.transfer_syntax == '1.2.840.10008.1.2.1'
             return 0x0000
 
@@ -1547,7 +1547,7 @@ class TestQRGetServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == PatientRootQueryRetrieveInformationModelGet.uid
+        assert self.scp.context.abstract_syntax == PatientRootQueryRetrieveInformationModelGet
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()
@@ -1567,12 +1567,12 @@ class TestQRGetServiceClass(object):
         ae.add_requested_context(CTImageStorage, '1.2.840.10008.1.2.1')
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scu_role = False
         role.scp_role = True
 
         def on_c_store(ds, context, assoc_info):
-            assert context.abstract_syntax == CTImageStorage.uid
+            assert context.abstract_syntax == CTImageStorage
             assert context.transfer_syntax == '1.2.840.10008.1.2.1'
             return 0x0000
 
@@ -1673,7 +1673,7 @@ class TestQRMoveServiceClass(object):
         self.ds = Dataset()
         self.ds.file_meta = Dataset()
         self.ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
-        self.ds.SOPClassUID = CTImageStorage.uid
+        self.ds.SOPClassUID = CTImageStorage
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'
 
@@ -1711,7 +1711,7 @@ class TestQRMoveServiceClass(object):
 
         req = C_GET()
         req.MessageID = 1
-        req.AffectedSOPClassUID = PatientRootQueryRetrieveInformationModelMove.uid
+        req.AffectedSOPClassUID = PatientRootQueryRetrieveInformationModelMove
         req.Priority = 2
         # Encoded as Implicit VR Little
         req.Identifier = BytesIO(b'\x08\x00\x01\x00\x04\x00\x00\x00\x00\x08\x00\x49')
@@ -2601,7 +2601,7 @@ class TestQRMoveServiceClass(object):
         assoc.release()
         assert assoc.is_released
 
-        assert self.scp.context.abstract_syntax == PatientRootQueryRetrieveInformationModelMove.uid
+        assert self.scp.context.abstract_syntax == PatientRootQueryRetrieveInformationModelMove
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()
@@ -2693,7 +2693,7 @@ class TestQRCompositeInstanceWithoutBulk(object):
         self.ds = Dataset()
         self.ds.file_meta = Dataset()
         self.ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
-        self.ds.SOPClassUID = CTImageStorage.uid
+        self.ds.SOPClassUID = CTImageStorage
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'
 
@@ -2734,7 +2734,7 @@ class TestQRCompositeInstanceWithoutBulk(object):
         ae.add_requested_context(CTImageStorage)
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scp_role = True
         role.scu_role = False
 
@@ -2761,7 +2761,7 @@ class TestQRCompositeInstanceWithoutBulk(object):
     def test_waveform_sequence(self):
         """Test when on_c_get returns success status"""
         self.scp = DummyGetSCP()
-        self.ds.SOPClassUID = CTImageStorage.uid
+        self.ds.SOPClassUID = CTImageStorage
         self.ds.WaveformSequence = [Dataset(), Dataset()]
         self.ds.WaveformSequence[0].WaveformData = b'\x00\x01'
         self.ds.WaveformSequence[0].WaveformBitsAllocated = 16
@@ -2783,7 +2783,7 @@ class TestQRCompositeInstanceWithoutBulk(object):
         self.scp.start()
 
         role = SCP_SCU_RoleSelectionNegotiation()
-        role.sop_class_uid = CTImageStorage.uid
+        role.sop_class_uid = CTImageStorage
         role.scp_role = True
         role.scu_role = False
 
@@ -2820,7 +2820,7 @@ class TestBasicWorklistServiceClass(object):
         self.query.QueryRetrieveLevel = "PATIENT"
 
         self.ds = Dataset()
-        self.ds.SOPClassUID = CTImageStorage.uid
+        self.ds.SOPClassUID = CTImageStorage
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'
 

--- a/pynetdicom3/tests/test_service_qr.py
+++ b/pynetdicom3/tests/test_service_qr.py
@@ -18,7 +18,7 @@ import pytest
 
 from pydicom import dcmread
 from pydicom.dataset import Dataset
-from pydicom.uid import ExplicitVRLittleEndian
+from pydicom.uid import ImplicitVRLittleEndian, ExplicitVRLittleEndian
 
 from pynetdicom3 import AE, build_context, StoragePresentationContexts
 from pynetdicom3.dimse_primitives import C_FIND, C_GET
@@ -524,6 +524,8 @@ class TestQRGetServiceClass(object):
         self.query.QueryRetrieveLevel = "PATIENT"
 
         self.ds = Dataset()
+        self.ds.file_meta = Dataset()
+        self.ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         self.ds.SOPClassUID = CTImageStorage.uid
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'
@@ -662,6 +664,7 @@ class TestQRGetServiceClass(object):
 
         def on_c_store(ds, context, assoc_info):
             return 0x0000
+
         ae.on_c_store = on_c_store
         ae.acse_timeout = 5
         ae.dimse_timeout = 5
@@ -1668,6 +1671,8 @@ class TestQRMoveServiceClass(object):
         self.query.QueryRetrieveLevel = "PATIENT"
 
         self.ds = Dataset()
+        self.ds.file_meta = Dataset()
+        self.ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         self.ds.SOPClassUID = CTImageStorage.uid
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'
@@ -2645,7 +2650,7 @@ class TestQRMoveServiceClass(object):
         self.scp.stop()
 
     def test_scp_callback_move_aet(self):
-        """Test on_c_store caontext parameter"""
+        """Test on_c_move move_aet parameter"""
         self.scp = DummyMoveSCP()
         self.scp.no_suboperations = 1
         self.scp.statuses = [Dataset(), 0x0000]
@@ -2686,6 +2691,8 @@ class TestQRCompositeInstanceWithoutBulk(object):
         self.query.QueryRetrieveLevel = "PATIENT"
 
         self.ds = Dataset()
+        self.ds.file_meta = Dataset()
+        self.ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
         self.ds.SOPClassUID = CTImageStorage.uid
         self.ds.SOPInstanceUID = '1.1.1'
         self.ds.PatientName = 'Test'

--- a/pynetdicom3/tests/test_service_relevant_patient.py
+++ b/pynetdicom3/tests/test_service_relevant_patient.py
@@ -71,7 +71,7 @@ class TestRelevantPatientServiceClass(object):
 
         req = C_FIND()
         req.MessageID = 1
-        req.AffectedSOPClassUID = GeneralRelevantPatientInformationQuery.uid
+        req.AffectedSOPClassUID = GeneralRelevantPatientInformationQuery
         req.Priority = 2
         req.Identifier = BytesIO(b'\x08\x00\x01\x00\x04\x00\x00\x00\x00\x08\x00\x49')
         assoc.dimse.send_msg(req, 1)
@@ -439,7 +439,7 @@ class TestRelevantPatientServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == GeneralRelevantPatientInformationQuery.uid
+        assert self.scp.context.abstract_syntax == GeneralRelevantPatientInformationQuery
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()

--- a/pynetdicom3/tests/test_service_storage.py
+++ b/pynetdicom3/tests/test_service_storage.py
@@ -197,7 +197,7 @@ class TestStorageServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == CTImageStorage.UID
+        assert self.scp.context.abstract_syntax == CTImageStorage
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()

--- a/pynetdicom3/tests/test_service_substance_admin.py
+++ b/pynetdicom3/tests/test_service_substance_admin.py
@@ -69,7 +69,7 @@ class TestQRFindServiceClass(object):
 
         req = C_FIND()
         req.MessageID = 1
-        req.AffectedSOPClassUID = ProductCharacteristicsQueryInformationModelFind.uid
+        req.AffectedSOPClassUID = ProductCharacteristicsQueryInformationModelFind
         req.Priority = 2
         req.Identifier = BytesIO(b'\x08\x00\x01\x00\x04\x00\x00\x00\x00\x08\x00\x49')
         assoc.dimse.send_msg(req, 1)
@@ -441,7 +441,7 @@ class TestQRFindServiceClass(object):
         assert assoc.is_released
 
         assert self.scp.context.context_id == 1
-        assert self.scp.context.abstract_syntax == ProductCharacteristicsQueryInformationModelFind.uid
+        assert self.scp.context.abstract_syntax == ProductCharacteristicsQueryInformationModelFind
         assert self.scp.context.transfer_syntax == '1.2.840.10008.1.2.1'
 
         self.scp.stop()

--- a/pynetdicom3/tests/test_sop.py
+++ b/pynetdicom3/tests/test_sop.py
@@ -87,8 +87,7 @@ class TestUIDtoSOPlass(object):
     def test_missing_sop(self):
         """Test SOP Class if UID not found."""
         sop_class = uid_to_sop_class('1.2.3.4')
-        assert sop_class.uid == '1.2.3.4'
-        assert sop_class.UID == '1.2.3.4'
+        assert sop_class == '1.2.3.4'
         assert sop_class.service_class == ServiceClass
 
     def test_verification_uid(self):
@@ -170,75 +169,70 @@ class TestUIDToServiceClass(object):
 
 class TestSOPClass(object):
     """Tests for sop_class.SOPClass."""
-    def test_functional(self):
-        """Test basic functionality."""
-        sop = SOPClass('1.2.3', '1.2.3', VerificationServiceClass)
-        assert sop.uid == '1.2.3'
-        assert sop.UID == '1.2.3'
-        assert sop.service_class == VerificationServiceClass
+    def test_creation(self):
+        """Test creating a new UIDSOPClass."""
+        sop_class = SOPClass('1.2.3')
+        sop_class._service_class = ServiceClass
+
+        assert sop_class == '1.2.3'
+        assert sop_class.service_class == ServiceClass
+
+        sop_class_b = SOPClass(sop_class)
+        assert sop_class == sop_class_b
+        assert sop_class_b == '1.2.3'
+        assert sop_class_b.service_class == ServiceClass
 
     def test_verification_sop(self):
         """Test a Verification Service SOP Class."""
-        assert VerificationSOPClass.uid == '1.2.840.10008.1.1'
-        assert VerificationSOPClass.UID == '1.2.840.10008.1.1'
+        assert VerificationSOPClass == '1.2.840.10008.1.1'
         assert VerificationSOPClass.service_class == VerificationServiceClass
 
     def test_storage_sop(self):
         """Test a Storage Service SOP Class."""
-        assert CTImageStorage.uid == '1.2.840.10008.5.1.4.1.1.2'
-        assert CTImageStorage.UID == '1.2.840.10008.5.1.4.1.1.2'
+        assert CTImageStorage == '1.2.840.10008.5.1.4.1.1.2'
         assert CTImageStorage.service_class == StorageServiceClass
 
     def test_qr_sop(self):
         """Test a Query/Retrieve Service SOP Class."""
-        assert StudyRootQueryRetrieveInformationModelFind.uid == '1.2.840.10008.5.1.4.1.2.2.1'
-        assert StudyRootQueryRetrieveInformationModelFind.UID == '1.2.840.10008.5.1.4.1.2.2.1'
+        assert StudyRootQueryRetrieveInformationModelFind == '1.2.840.10008.5.1.4.1.2.2.1'
         assert StudyRootQueryRetrieveInformationModelFind.service_class == QueryRetrieveServiceClass
 
     def test_basic_worklist_sop(self):
         """Test a Basic Worklist Service SOP Class."""
-        assert ModalityWorklistInformationFind.uid == '1.2.840.10008.5.1.4.31'
-        assert ModalityWorklistInformationFind.UID == '1.2.840.10008.5.1.4.31'
+        assert ModalityWorklistInformationFind == '1.2.840.10008.5.1.4.31'
         assert ModalityWorklistInformationFind.service_class == BasicWorklistManagementServiceClass
 
     def test_relevant_patient_info_sop(self):
         """Test a Relevant Patient Information Query Service SOP Class."""
-        assert GeneralRelevantPatientInformationQuery.uid == '1.2.840.10008.5.1.4.37.1'
-        assert GeneralRelevantPatientInformationQuery.UID == '1.2.840.10008.5.1.4.37.1'
+        assert GeneralRelevantPatientInformationQuery == '1.2.840.10008.5.1.4.37.1'
         assert GeneralRelevantPatientInformationQuery.service_class == RelevantPatientInformationQueryServiceClass
 
     def test_substance_admin_sop(self):
         """Test s Substance Administration Query Service SOP Class."""
-        assert ProductCharacteristicsQueryInformationModelFind.uid == '1.2.840.10008.5.1.4.41'
-        assert ProductCharacteristicsQueryInformationModelFind.UID == '1.2.840.10008.5.1.4.41'
+        assert ProductCharacteristicsQueryInformationModelFind == '1.2.840.10008.5.1.4.41'
         assert ProductCharacteristicsQueryInformationModelFind.service_class == SubstanceAdministrationQueryServiceClass
 
     def test_non_patient_sop(self):
         """Test a Non-Patient Object Service SOP Class."""
-        assert HangingProtocolStorage.uid == '1.2.840.10008.5.1.4.38.1'
-        assert HangingProtocolStorage.UID == '1.2.840.10008.5.1.4.38.1'
+        assert HangingProtocolStorage == '1.2.840.10008.5.1.4.38.1'
         assert HangingProtocolStorage.service_class == NonPatientObjectStorageServiceClass
 
     def test_hanging_protocol_sop(self):
         """Test a Hanging Protocol Service SOP Class."""
-        assert HangingProtocolInformationModelGet.uid == '1.2.840.10008.5.1.4.38.4'
-        assert HangingProtocolInformationModelGet.UID == '1.2.840.10008.5.1.4.38.4'
+        assert HangingProtocolInformationModelGet == '1.2.840.10008.5.1.4.38.4'
         assert HangingProtocolInformationModelGet.service_class == HangingProtocolQueryRetrieveServiceClass
 
     def test_defined_procedure_sop(self):
         """Test a Defined Procedure Protocol Service SOP Class."""
-        assert DefinedProcedureProtocolInformationModelFind.uid == '1.2.840.10008.5.1.4.20.1'
-        assert DefinedProcedureProtocolInformationModelFind.UID == '1.2.840.10008.5.1.4.20.1'
+        assert DefinedProcedureProtocolInformationModelFind == '1.2.840.10008.5.1.4.20.1'
         assert DefinedProcedureProtocolInformationModelFind.service_class == DefinedProcedureProtocolQueryRetrieveServiceClass
 
     def test_color_palette_sop(self):
         """Test a Color Palette Service SOP Class."""
-        assert ColorPaletteInformationModelMove.uid == '1.2.840.10008.5.1.4.39.3'
-        assert ColorPaletteInformationModelMove.UID == '1.2.840.10008.5.1.4.39.3'
+        assert ColorPaletteInformationModelMove == '1.2.840.10008.5.1.4.39.3'
         assert ColorPaletteInformationModelMove.service_class == ColorPaletteQueryRetrieveServiceClass
 
     def test_implant_template_sop(self):
         """Test an Implant Template Service SOP Class."""
-        assert ImplantTemplateGroupInformationModelFind.uid == '1.2.840.10008.5.1.4.45.2'
-        assert ImplantTemplateGroupInformationModelFind.UID == '1.2.840.10008.5.1.4.45.2'
+        assert ImplantTemplateGroupInformationModelFind == '1.2.840.10008.5.1.4.45.2'
         assert ImplantTemplateGroupInformationModelFind.service_class == ImplantTemplateQueryRetrieveServiceClass

--- a/pynetdicom3/tests/test_sop.py
+++ b/pynetdicom3/tests/test_sop.py
@@ -94,6 +94,12 @@ class TestUIDtoSOPlass(object):
         """Test normal function"""
         assert uid_to_sop_class('1.2.840.10008.1.1') == VerificationSOPClass
 
+    def test_existing(self):
+        """Test that the existing class is returned."""
+        original = VerificationSOPClass
+        sop_class = uid_to_sop_class('1.2.840.10008.1.1')
+        assert id(sop_class) == id(original)
+
 
 class TestUIDToServiceClass(object):
     """Tests for sop_class.uid_to_service_class."""


### PR DESCRIPTION
#### Changes
* Fix being able to send datasets with unmatched transfer syntaxes (#206)
* Improve access methods for the presentation contexts available to an established association
* Better logging/exception messages when contexts aren't accepted or wrong mode
* Change `SOPClass` to inherit from `UID`

#### Tasks
 - [x] Unit tests added that reproduce issue or prove feature is working
 - [x] Fix or feature added
 - [x] Documentation updated (if relevant)
 - [x] Unit tests passing after adding fix/feature
 - [x] Apps tested (if relevant)