### PR TITLE
[MRG] Add callbacks for SOP Class Extended Negotiation, Async Ops

### DIFF
--- a/docs/changelog/0.9.1.rst
+++ b/docs/changelog/0.9.1.rst
@@ -75,3 +75,7 @@ Enhancements
 * Add support for N-GET, N-SET, N-EVENT-REPORT, N-DELETE, N-ACTION, N-CREATE
   as SCU.
 * Add full support for SCP/SCU Role Selection Negotiation
+* Add support for SOP Class Extended Negotiation
+* Add support for Asynchronous Operations Window Negotiation, however
+  pynetdicom does not support asynchronous operations.
+* Add support for User Identity Negotiation

--- a/docs/user/association.rst
+++ b/docs/user/association.rst
@@ -173,6 +173,15 @@ For more information on using the services available to an association please
 read through the :ref:`examples <index_examples>` corresponding to the
 service class you're interested in.
 
+Accessing User Identity Responses
+---------------------------------
+
+If the association requestor has sent a User Identity Negotiation item as
+part of the extended negotiation and has requested a response in the event of
+a positive identification then it can be accessed via the
+:py:meth:`Assocation.user_identity_response <pynetdicom3.association.Association.user_identity_response>`
+property after the association has been established.
+
 .. _assoc_scp:
 
 Listening for Association Requests (SCP)

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -1549,6 +1549,9 @@ class ApplicationEntity(object):
                   'originator_aet' : bytes or None, the move originator's AE title
                   'originator_message_id' : int or None, the move originator's message ID
               }
+              'sop_class_extended' : {
+                  SOP Class UID : Service Class Application Information,
+              }
 
         Returns
         -------
@@ -1648,6 +1651,9 @@ class ApplicationEntity(object):
               'parameters' : {
                   'message_id' : int, the DIMSE message ID
                   'priority' : int, the requested operation priority
+              }
+              'sop_class_extended' : {
+                  SOP Class UID : Service Class Application Information,
               }
 
         Yields
@@ -1790,6 +1796,9 @@ class ApplicationEntity(object):
               'parameters' : {
                   'message_id' : int, the DIMSE message ID
                   'priority' : int, the requested operation priority
+              }
+              'sop_class_extended' : {
+                  SOP Class UID : Service Class Application Information,
               }
 
         Yields
@@ -1940,6 +1949,9 @@ class ApplicationEntity(object):
                   'message_id' : int, the DIMSE message ID
                   'priority' : int, the requested operation priority
               }
+              'sop_class_extended' : {
+                  SOP Class UID : Service Class Application Information,
+              }
 
         Yields
         ------
@@ -2077,6 +2089,9 @@ class ApplicationEntity(object):
                   'originator_aet' : bytes or None, the move originator's AE title
                   'originator_message_id' : int or None, the move originator's message ID
               }
+              'sop_class_extended' : {
+                  SOP Class UID : Service Class Application Information,
+              }
 
         Returns
         -------
@@ -2199,6 +2214,9 @@ class ApplicationEntity(object):
                   Class UID value
                   'requested_sop_instance' : str, the N-GET-RQ's requested SOP
                   Instance UID value
+              }
+              'sop_class_extended' : {
+                  SOP Class UID : Service Class Application Information,
               }
 
         Returns

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -1369,6 +1369,34 @@ class ApplicationEntity(object):
 
 
     # Association extended negotiation callbacks
+    def on_sop_class_extended(self, app_info):
+        """Callback for when one or more SOP Class Extended Negotiation items
+        are included in the association request.
+
+        Parameters
+        ----------
+        app_info : dict of pydicom.uid.UID, bytes
+            The {*SOP Class UID* : *Service Class Application Information*}
+            parameter values for the included items, with the service class
+            application information being the raw encoded data sent by the
+            requestor.
+
+        Returns
+        -------
+        dict of pydicom.uid.UID, bytes or None
+            The {*SOP Class UID* : *Service Class Application Information*}
+            parameter values to be sent in response to the request, with the
+            service class application information being the encoded data that
+            will be sent to the peer as-is. Return None if no response is to
+            be sent.
+
+        References
+        ----------
+
+        * DICOM Standard Part 7, `Annex D.3.3.5 <http://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_D.3.3.5.html>`_
+        """
+        return None
+
     def on_user_identity(self, user_id_type, primary_field,
                          secondary_field, info):
         """Callback for when a user identity negotiation item is included with
@@ -1427,34 +1455,6 @@ class ApplicationEntity(object):
         * DICOM Standard Part 7, `Annex D.3.3.7 <http://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_D.3.3.7.html>`_
         """
         raise NotImplementedError("User Identity Negotiation not implemented")
-
-    def on_sop_class_extended(self, app_info):
-        """Callback for when one or more SOP Class Extended Negotiation items
-        are included in the association request.
-
-        Parameters
-        ----------
-        app_info : dict of pydicom.uid.UID, bytes
-            The {*SOP Class UID* : *Service Class Application Information*}
-            parameter values for the included items, with the service class
-            application information being the raw encoded data sent by the
-            requestor.
-
-        Returns
-        -------
-        dict of pydicom.uid.UID, bytes or None
-            The {*SOP Class UID* : *Service Class Application Information*}
-            parameter values to be sent in response to the request, with the
-            service class application information being the encoded data that
-            will be sent to the peer as-is. Return None if no response is to
-            be sent.
-
-        References
-        ----------
-
-        * DICOM Standard Part 7, `Annex D.3.3.5 <http://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_D.3.3.5.html>`_
-        """
-        return None
 
 
     # High-level DIMSE-C callbacks - user should implement these as required

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -1369,6 +1369,44 @@ class ApplicationEntity(object):
 
 
     # Association extended negotiation callbacks
+    def on_async_ops_window(self, nr_invoked, nr_performed):
+        """Callback for when an Asynchronous Operations Window Negotiation
+        item is include in the association request.
+
+        Asynchronous operations are not supported by pynetdicom3 and any
+        request will always return the default number of operations
+        invoked/performed (1, 1), regardless of what values are returned by
+        this callback.
+
+        If the callback is not implemented then no response to the Asynchronous
+        Operations Window Negotiation will be sent to the association
+        requestor.
+
+        Parameters
+        ----------
+        nr_invoked : int
+            The *Maximum Number Operations Invoked* parameter value of the
+            Asynchronous Operations Window request. If the value is 0 then
+            an unlimited number of invocations are requested.
+        nr_performed : int
+            The *Maximum Number Operations Performed* parameter value of the
+            Asynchronous Operations Window request. If the value is 0 then
+            an unlimited number of performances are requested.
+
+        Returns
+        -------
+        int, int
+            The (maximum number operations invoked, maximum number operations
+            performed). A value of 0 indicates that an unlimited number of
+            operations is supported. As asynchronous operations are not
+            currently supported the return value will be ignored and (1, 1).
+            sent in response.
+        """
+        raise NotImplementedError(
+            "No Asynchronous Operations Window Negotiation response will be "
+            "sent"
+        )
+
     def on_sop_class_extended(self, app_info):
         """Callback for when one or more SOP Class Extended Negotiation items
         are included in the association request.

--- a/pynetdicom3/ae.py
+++ b/pynetdicom3/ae.py
@@ -1368,7 +1368,7 @@ class ApplicationEntity(object):
                 )
 
 
-    # Association negotiation callbacks
+    # Association extended negotiation callbacks
     def on_user_identity(self, user_id_type, primary_field,
                          secondary_field, info):
         """Callback for when a user identity negotiation item is included with
@@ -1427,6 +1427,34 @@ class ApplicationEntity(object):
         * DICOM Standard Part 7, `Annex D.3.3.7 <http://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_D.3.3.7.html>`_
         """
         raise NotImplementedError("User Identity Negotiation not implemented")
+
+    def on_sop_class_extended(self, app_info):
+        """Callback for when one or more SOP Class Extended Negotiation items
+        are included in the association request.
+
+        Parameters
+        ----------
+        app_info : dict of pydicom.uid.UID, bytes
+            The {*SOP Class UID* : *Service Class Application Information*}
+            parameter values for the included items, with the service class
+            application information being the raw encoded data sent by the
+            requestor.
+
+        Returns
+        -------
+        dict of pydicom.uid.UID, bytes or None
+            The {*SOP Class UID* : *Service Class Application Information*}
+            parameter values to be sent in response to the request, with the
+            service class application information being the encoded data that
+            will be sent to the peer as-is. Return None if no response is to
+            be sent.
+
+        References
+        ----------
+
+        * DICOM Standard Part 7, `Annex D.3.3.5 <http://dicom.nema.org/medical/dicom/current/output/chtml/part07/sect_D.3.3.5.html>`_
+        """
+        return None
 
 
     # High-level DIMSE-C callbacks - user should implement these as required

--- a/pynetdicom3/pdu_primitives.py
+++ b/pynetdicom3/pdu_primitives.py
@@ -1912,10 +1912,8 @@ class SOPClassCommonExtendedNegotiation(ServiceParameter):
                                     "pydicom.uid.UID, str or bytes")
 
                 if uid is not None and not uid.is_valid:
-                    LOGGER.error("Related General SOP Class "
-                                 "Identification contains an invalid UID")
-                    raise ValueError("Related General SOP Class contains "
-                                     "an invalid UID")
+                    LOGGER.warning("Related General SOP Class "
+                                   "Identification contains an invalid UID")
 
                 valid_uid_list.append(uid)
 
@@ -1963,8 +1961,7 @@ class SOPClassCommonExtendedNegotiation(ServiceParameter):
                             "str or bytes")
 
         if value is not None and not value.is_valid:
-            LOGGER.error("Implementation Class UID is an invalid UID")
-            raise ValueError("Implementation Class UID is an invalid UID")
+            LOGGER.warning("Implementation Class UID is an invalid UID")
 
         self._service_class_uid = value
 
@@ -2003,8 +2000,7 @@ class SOPClassCommonExtendedNegotiation(ServiceParameter):
                             "or bytes")
 
         if value is not None and not value.is_valid:
-            LOGGER.error("Implementation Class UID is an invalid UID")
-            raise ValueError("Implementation Class UID is an invalid UID")
+            LOGGER.warning("Implementation Class UID is an invalid UID")
 
         self._sop_class_uid = value
 

--- a/pynetdicom3/presentation.py
+++ b/pynetdicom3/presentation.py
@@ -144,7 +144,7 @@ class PresentationContext(object):
 
     - If no role selection negotiation then the requestor is SCU and the
       acceptor is SCP
-    - The association acceptor cannot return accept a role that has not been
+    - The association acceptor cannot accept a role that has not been
       proposed (i.e. cannot return 1 when the proposed value is 0).
     - The association requestor may be SCP only, SCU only or both SCU and SCP.
 

--- a/pynetdicom3/service_class.py
+++ b/pynetdicom3/service_class.py
@@ -139,8 +139,6 @@ class ServiceClass(object):
         return rsp
 
 
-
-
 # Service Class implementations
 class VerificationServiceClass(ServiceClass):
     """Implementation of the Verification Service Class."""

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -295,6 +295,11 @@ class TestAEGoodCallbacks(object):
         with pytest.raises(NotImplementedError):
             ae.on_user_identity(None, None, None, None)
 
+    def test_on_sop_class_extended(self):
+        """Test default callback returns None"""
+        ae = AE()
+        assert ae.on_sop_class_extended(None) is None
+
     def test_on_c_echo(self):
         """Test default callback raises exception"""
         ae = AE()

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -33,7 +33,7 @@ from pynetdicom3.dsutils import encode, decode
 from pynetdicom3.pdu_primitives import (
     UserIdentityNegotiation, SOPClassExtendedNegotiation,
     SOPClassCommonExtendedNegotiation, SCP_SCU_RoleSelectionNegotiation,
-    AsynchronousOperationsWindowNegotiation,
+    AsynchronousOperationsWindowNegotiation, A_ASSOCIATE,
 )
 from pynetdicom3.sop_class import (
     VerificationSOPClass,
@@ -1062,6 +1062,21 @@ class TestAssociationSendCEcho(object):
         assert cx.abstract_syntax == CTImageStorage
         assoc.release()
         assert assoc.is_released
+        self.scp.stop()
+
+    def test_request(self):
+        """Test the Association.request property."""
+        self.scp = DummyVerificationSCP()
+        self.scp.start()
+        ae = AE()
+        ae.add_requested_context(VerificationSOPClass)
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+        req = assoc.request
+        assert isinstance(req, type(None))
+
         self.scp.stop()
 
 

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -3988,21 +3988,7 @@ class TestSOPClassExtendedNegotiation(object):
     def test_functional_response(self):
         """Test a functional workflow with response."""
         def on_ext(req):
-            assert isinstance(req, dict)
-            out = []
-            for k, v in req.items():
-                if k == '1.2.3':
-                    assert v == b'\x00\x01'
-                else:
-                    assert k == '1.2.4'
-                    assert v == b'\x00\x02'
-
-                item = SOPClassExtendedNegotiation()
-                item.sop_class_uid = k
-                item.service_class_application_information = v
-                item.append(out)
-
-            return out
+            return req
 
         self.scp = DummyVerificationSCP()
         self.scp.ae.on_sop_class_extended = on_ext

--- a/pynetdicom3/tests/test_primitives.py
+++ b/pynetdicom3/tests/test_primitives.py
@@ -48,13 +48,13 @@ class TestPrimitive_MaximumLengthNegotiation(unittest.TestCase):
         self.assertTrue(primitive.maximum_length_received == 45)
 
         # Check exceptions
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.maximum_length_received = 45.2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.maximum_length_received = -1
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.maximum_length_received = 'abc'
 
     def test_conversion(self):
@@ -104,17 +104,17 @@ class TestPrimitive_ImplementationClassUIDNotification(unittest.TestCase):
         primitive = ImplementationClassUIDNotification()
 
         # No value set
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         # Non UID, bytes or str
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.implementation_class_uid = 45.2
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.implementation_class_uid = 100
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.implementation_class_uid = 'abc'
 
     def test_conversion(self):
@@ -158,17 +158,17 @@ class TestPrimitive_ImplementationVersionNameNotification(unittest.TestCase):
         primitive = ImplementationVersionNameNotification()
 
         # No value set
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         # Non UID, bytes or str
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.implementation_version_name = 45.2
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.implementation_version_name = 100
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.implementation_version_name = 'ABCD1234ABCD12345'
 
     def test_conversion(self):
@@ -203,22 +203,22 @@ class TestPrimitive_AsynchronousOperationsWindowNegotiation(unittest.TestCase):
         self.assertTrue(primitive.maximum_number_operations_performed == 11)
 
         ## Check exceptions
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.maximum_number_operations_invoked = 45.2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.maximum_number_operations_invoked = -1
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.maximum_number_operations_invoked = 'ABCD1234ABCD12345'
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.maximum_number_operations_performed = 45.2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.maximum_number_operations_performed = -1
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.maximum_number_operations_performed = 'ABCD1234ABCD12345'
 
     def test_conversion(self):
@@ -266,38 +266,38 @@ class TestPrimitive_SCP_SCU_RoleSelectionNegotiation(unittest.TestCase):
         self.assertTrue(primitive.scu_role == True)
 
         ## Check exceptions
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.sop_class_uid = 10
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.sop_class_uid = 45.2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.sop_class_uid = 'abc'
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.scp_role = 1
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.scp_role = 'abc'
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.scu_role = 1
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.scu_role = 'abc'
 
         # No value set
         primitive = SCP_SCU_RoleSelectionNegotiation()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive.sop_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive.scp_role = False
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive = SCP_SCU_RoleSelectionNegotiation()
@@ -310,7 +310,7 @@ class TestPrimitive_SCP_SCU_RoleSelectionNegotiation(unittest.TestCase):
         primitive = SCP_SCU_RoleSelectionNegotiation()
         primitive.scp_role = True
         primitive.scu_role = True
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
     def test_conversion(self):
@@ -329,7 +329,7 @@ class TestPrimitive_SCP_SCU_RoleSelectionNegotiation(unittest.TestCase):
         primitive.sop_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
         primitive.scp_role = False
         primitive.scu_role = False
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.from_primitive()
 
 
@@ -357,38 +357,38 @@ class TestPrimitive_SOPClassExtendedNegotiation(unittest.TestCase):
 
         ## Check exceptions
         # SOP Class UID
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.sop_class_uid = 10
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.sop_class_uid = 45.2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.sop_class_uid = 'abc'
 
         # Service Class Application Information
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.service_class_application_information = 10
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.service_class_application_information = 45.2
 
         # Python 2 compatibility all bytes are str
-        #with self.assertRaises(TypeError):
+        #with pytest.raises(TypeError):
         #    primitive.service_class_application_information = 'abc'
 
         # No value set
         primitive = SOPClassExtendedNegotiation()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive.sop_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive = SOPClassExtendedNegotiation()
         primitive.service_class_application_information = b'\x02\x00\x03\x00\x01\x00'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
     def test_conversion(self):
@@ -413,82 +413,75 @@ class TestPrimitive_SOPClassCommonExtendedNegotiation(unittest.TestCase):
         reference_uid = UID('1.2.840.10008.5.1.4.1.1.2')
 
         primitive.sop_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
-        self.assertTrue(primitive.sop_class_uid == reference_uid)
-
+        assert primitive.sop_class_uid == reference_uid
+        primitive.sop_class_uid = 'abc'
+        assert primitive.sop_class_uid == 'abc'
         primitive.sop_class_uid = '1.2.840.10008.5.1.4.1.1.2'
-        self.assertTrue(primitive.sop_class_uid == reference_uid)
-
+        assert primitive.sop_class_uid == reference_uid
         primitive.sop_class_uid = UID('1.2.840.10008.5.1.4.1.1.2')
-        self.assertTrue(primitive.sop_class_uid == reference_uid)
+        assert primitive.sop_class_uid == reference_uid
 
         # Service Class UID
         primitive.service_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
-        self.assertTrue(primitive.service_class_uid == reference_uid)
-
+        assert primitive.service_class_uid == reference_uid
+        primitive.service_class_uid = 'abc'
+        assert primitive.service_class_uid == 'abc'
         primitive.service_class_uid = '1.2.840.10008.5.1.4.1.1.2'
-        self.assertTrue(primitive.service_class_uid == reference_uid)
-
+        assert primitive.service_class_uid == reference_uid
         primitive.service_class_uid = UID('1.2.840.10008.5.1.4.1.1.2')
-        self.assertTrue(primitive.service_class_uid == reference_uid)
+        assert primitive.service_class_uid == reference_uid
 
         # Related General SOP Class Identification
-        ref_uid_list = [UID('1.2.840.10008.5.1.4.1.1.2'),
-                        UID('1.2.840.10008.5.1.4.1.1.3'),
-                        UID('1.2.840.10008.5.1.4.1.1.4')]
+        ref_list = [UID('1.2.840.10008.5.1.4.1.1.2'),
+                    UID('1.2.840.10008.5.1.4.1.1.3'),
+                    UID('1.2.840.10008.5.1.4.1.1.4')]
 
         uid_list = []
         uid_list.append(b'1.2.840.10008.5.1.4.1.1.2')
         uid_list.append('1.2.840.10008.5.1.4.1.1.3')
         uid_list.append(UID('1.2.840.10008.5.1.4.1.1.4'))
         primitive.related_general_sop_class_identification = uid_list
-        self.assertTrue(primitive.related_general_sop_class_identification == ref_uid_list)
+        assert primitive.related_general_sop_class_identification == ref_list
+        primitive.related_general_sop_class_identification = ['abc']
+        assert primitive.related_general_sop_class_identification == ['abc']
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.related_general_sop_class_identification = 'test'
 
         ## Check exceptions
         # SOP Class UID
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.sop_class_uid = 10
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.sop_class_uid = 45.2
 
-        with self.assertRaises(ValueError):
-            primitive.sop_class_uid = 'abc'
-
         # Service Class UID
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.service_class_uid = 10
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.service_class_uid = 45.2
 
-        with self.assertRaises(ValueError):
-            primitive.service_class_uid = 'abc'
-
         # Related General SOP Class Identification
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.related_general_sop_class_identification = [10]
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.related_general_sop_class_identification = [45.2]
-
-        with self.assertRaises(ValueError):
-            primitive.related_general_sop_class_identification = ['abc']
 
         # No value set
         primitive = SOPClassCommonExtendedNegotiation()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive.sop_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
         primitive = SOPClassCommonExtendedNegotiation()
         primitive.service_class_uid = b'1.2.840.10008.5.1.4.1.1.2'
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             item = primitive.from_primitive()
 
     def test_conversion(self):
@@ -692,105 +685,105 @@ class TestPrimitive_A_ASSOCIATE(unittest.TestCase):
         assoc = A_ASSOCIATE()
 
         # application_context_name
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.application_context_name = 10
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.application_context_name = 45.2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.application_context_name = 'abc'
 
         # calling_ae_title
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.calling_ae_title = 45.2
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.calling_ae_title = 100
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.calling_ae_title = ''
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.calling_ae_title = '    '
 
         # called_ae_title
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.called_ae_title = 45.2
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.called_ae_title = 100
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.called_ae_title = ''
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.called_ae_title = '    '
 
         # user_information
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.user_information = 45.2
 
         # result
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.result = -1
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.result = 3
 
         # result_source
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.result_source = 0
 
         # result_source
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.result_source = 4
 
         # diagnostic
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.diagnostic = 0
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.diagnostic = 4
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.diagnostic = 5
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.diagnostic = 6
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.diagnostic = 8
 
         # calling_presentation_addresss
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.calling_presentation_address = ['10.40.94.43', 105]
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.calling_presentation_address = (105, '10.40.94.43')
 
         # called_presentation_addresss
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.called_presentation_address = ['10.40.94.43', 105]
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.called_presentation_address = (105, '10.40.94.43')
 
         # presentation_context_definition_list
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.presentation_context_definition_list = 45.2
 
         # presentation_context_definition_results_list
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             assoc.presentation_context_definition_results_list = 45.2
 
         # implementation_class_uid
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             x = assoc.implementation_class_uid
 
         imp_uid = ImplementationClassUIDNotification()
         assoc.user_information.append(imp_uid)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             x = assoc.implementation_class_uid
 
     def test_conversion(self):
@@ -850,7 +843,7 @@ class TestPrimitive_A_RELEASE(unittest.TestCase):
         with self.assertRaises(AttributeError):
             assoc.reason = "something"
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             assoc.result = "accepted"
 
 
@@ -867,10 +860,10 @@ class TestPrimitive_A_ABORT(unittest.TestCase):
         """ Check incorrect types/values for properties raise exceptions """
         primitive = A_ABORT()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.abort_source = 1
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.abort_source
 
     def test_conversion(self):
@@ -906,9 +899,9 @@ class TestPrimitive_A_P_ABORT(unittest.TestCase):
         """ Check incorrect types/values for properties raise exceptions """
         primitive = A_P_ABORT()
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.provider_reason = 3
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             primitive.provider_reason
 
     def test_conversion(self):
@@ -934,16 +927,16 @@ class TestPrimitive_P_DATA(unittest.TestCase):
         """ Check incorrect types/values for properties raise exceptions """
         primitive = P_DATA()
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.presentation_data_value_list = ([1, b'\x00'])
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.presentation_data_value_list = [1, b'\x00']
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.presentation_data_value_list = [[b'\x00', 1]]
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             primitive.presentation_data_value_list = 'test'
 
     def test_conversion(self):


### PR DESCRIPTION
* Add support for SOP Class Extended Negotiation
* Add support for sending/receiving Asynchronous Operations Window Negotiation items, however asynchronous operations are not supported by pynetdicom.
* Add `Association` properties for retrieving extended negotiation item responses.
  * `Association.user_identity_response`
  * `Association.asynchronous_operations_response`
  * `Association.sop_class_extended_response`

#### Tasks
 - [ ] Unit tests added that reproduce issue or prove feature is working
 - [ ] Fix or feature added
 - [ ] Documentation updated (if relevant)
 - [ ] Unit tests passing after adding fix/feature
